### PR TITLE
Feat: support for generic return in Tokenizer class

### DIFF
--- a/lib/src/common/tokenizer.dart
+++ b/lib/src/common/tokenizer.dart
@@ -19,5 +19,5 @@ abstract class Tokenizer<T extends Object> {
   final RegExp? separatorRegExp;
   Tokenizer({this.separatorRegExp});
   bool canTokenizeText(String text);
-  List<T> tokenize(String content);
+  T tokenize(String content);
 }

--- a/lib/src/common/tokenizer.dart
+++ b/lib/src/common/tokenizer.dart
@@ -12,15 +12,12 @@ const String _nonWordsCharacters =
 // on [unicode categories](https://www.regular-expressions.info/unicode.html#category)
 
 /// A interface with the necessary methods to tokenize words
-abstract class Tokenizer {
+abstract class Tokenizer<T extends Object> {
   final RegExp defaultSeparatorRegExp = RegExp(
       '''([$_whitespaces]+|[$_allWords]+|[$_nonWordsCharacters])''',
       unicode: true);
   final RegExp? separatorRegExp;
   Tokenizer({this.separatorRegExp});
   bool canTokenizeText(String text);
-  List<String> tokenize(String content,
-      {@Deprecated(
-          'removeAllEmptyWords are no longer used and will be removed in future releases')
-      bool removeAllEmptyWords = false});
+  List<T> tokenize(String content);
 }

--- a/lib/src/multi_spell_checker.dart
+++ b/lib/src/multi_spell_checker.dart
@@ -9,9 +9,12 @@ import 'package:simple_spell_checker/simple_spell_checker.dart'
 import 'package:simple_spell_checker/src/common/extensions.dart';
 import 'package:simple_spell_checker/src/common/strategy_language_search_order.dart';
 import 'package:simple_spell_checker/src/spell_checker_interface/abtract_checker.dart';
+import 'package:simple_spell_checker/src/spell_checker_interface/mixin/stream_checks.dart';
 import 'package:simple_spell_checker/src/utils.dart'
     show defaultLanguagesDictionaries, isWordHasNumber;
+import 'package:simple_spell_checker/src/word_tokenizer.dart';
 import 'common/cache_object.dart' show CacheObject;
+import 'common/tokenizer.dart';
 
 CacheObject<List<LanguageIdentifier>>? _cacheLanguageIdentifiers;
 
@@ -38,11 +41,13 @@ CacheObject<Map<String, int>>? _cacheWordDictionary;
 // [setNewLanguage] method to override the current language from the class
 // second:
 // [reloadDictionary] or [reloadDictionarySync] methods to set a new state to the directionary
-class MultiSpellChecker extends Checker<List<String>, List<String>> {
+class MultiSpellChecker extends Checker<List<String>, List<String>>
+    implements CheckOperationsStreams<List<TextSpan>> {
   List<LanguageIdentifier>? customLanguages;
+  late Tokenizer<String> _wordTokenizer;
   MultiSpellChecker({
     required super.language,
-    super.wordTokenizer,
+    Tokenizer<String>? wordTokenizer,
     super.safeDictionaryLoad,
     super.worksWithoutDictionary,
     super.caseSensitive = false,
@@ -64,9 +69,9 @@ class MultiSpellChecker extends Checker<List<String>, List<String>> {
       worksWithoutDictionary: worksWithoutDictionary,
       safeLanguageName: safeLanguageName,
       strategy: strategy,
-      wordTokenizer: wordTokenizer,
       caseSensitive: caseSensitive,
     );
+    _wordTokenizer = wordTokenizer ?? WordTokenizer();
   }
 
   @protected
@@ -106,18 +111,18 @@ class MultiSpellChecker extends Checker<List<String>, List<String>> {
       throw UnsupportedError(
           'The ${getCurrentLanguage()} are not supported or registered on the [customLanguages]. Please, first add your new language using [registerLanguage] and after add the language identifier using [addCustomLanguage] to avoid this message.');
     }
-    if (!wordTokenizer.canTokenizeText(text)) return null;
+    if (!_wordTokenizer.canTokenizeText(text)) return null;
     final spans = <TextSpan>[];
-    final words = wordTokenizer.tokenize(text);
+    final words = _wordTokenizer.tokenize(text);
     for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i);
+      final word = words.elementAt(i).toString();
       final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
       if (isWordHasNumber(word) ||
           isWordValid(word) ||
           word.contains(' ') ||
           word.noWords) {
         if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex);
+          final nextWord = words.elementAt(nextIndex).toString();
           if (nextWord.contains(' ')) {
             spans.add(TextSpan(text: '$word$nextWord', style: commonStyle));
             // ignore the next since it was already passed
@@ -171,18 +176,18 @@ class MultiSpellChecker extends Checker<List<String>, List<String>> {
         !worksWithoutDictionary) {
       yield [];
     }
-    if (!wordTokenizer.canTokenizeText(text)) yield [];
+    if (!_wordTokenizer.canTokenizeText(text)) yield [];
     final spans = <TextSpan>[];
-    final words = wordTokenizer.tokenize(text);
+    final words = _wordTokenizer.tokenize(text);
     for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i);
+      final word = words.elementAt(i).toString();
       final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
       if (isWordHasNumber(word) ||
           isWordValid(word) ||
           word.contains(' ') ||
           word.noWords) {
         if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex);
+          final nextWord = words.elementAt(nextIndex).toString();
           if (nextWord.contains(' ')) {
             spans.add(TextSpan(text: '$word$nextWord', style: commonStyle));
             yield [...spans];
@@ -236,18 +241,18 @@ class MultiSpellChecker extends Checker<List<String>, List<String>> {
       throw UnsupportedError(
           'The ${getCurrentLanguage()} are not supported or registered on the [customLanguages]. Please, first add your new language using [registerLanguage] and after add the language identifier using [addCustomLanguage] to avoid this message.');
     }
-    if (!wordTokenizer.canTokenizeText(text)) return null;
+    if (!_wordTokenizer.canTokenizeText(text)) return null;
     final spans = <O>[];
-    final words = wordTokenizer.tokenize(text);
+    final words = _wordTokenizer.tokenize(text);
     for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i);
+      final word = words.elementAt(i).toString();
       final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
       if (isWordHasNumber(word) ||
           isWordValid(word) ||
           word.contains(' ') ||
           word.noWords) {
         if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex);
+          final nextWord = words.elementAt(nextIndex).toString();
           if (nextWord.contains(' ')) {
             spans.add(builder.call('$word$nextWord', true));
             // ignore the next since it was already passed
@@ -289,18 +294,18 @@ class MultiSpellChecker extends Checker<List<String>, List<String>> {
       throw UnsupportedError(
           'The ${getCurrentLanguage()} are not supported or registered on the [customLanguages]. Please, first add your new language using [registerLanguage] and after add the language identifier using [addCustomLanguage] to avoid this message.');
     }
-    if (!wordTokenizer.canTokenizeText(text)) yield [];
+    if (!_wordTokenizer.canTokenizeText(text)) yield [];
     final spans = <T>[];
-    final words = wordTokenizer.tokenize(text);
+    final words = _wordTokenizer.tokenize(text);
     for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i);
+      final word = words.elementAt(i).toString();
       final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
       if (isWordHasNumber(word) ||
           isWordValid(word) ||
           word.contains(' ') ||
           word.noWords) {
         if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex);
+          final nextWord = words.elementAt(nextIndex).toString();
           if (nextWord.contains(' ')) {
             spans.add(builder.call('$word$nextWord', true));
             yield [...spans];
@@ -395,6 +400,19 @@ class MultiSpellChecker extends Checker<List<String>, List<String>> {
     }
     _initLanguageCache(dictionaries);
     initDictionary('');
+  }
+
+  /// Set a new cusotm Tokenizer instance to be used by the package
+  void setNewTokenizer(Tokenizer<String> tokenizer) {
+    verifyState();
+    _wordTokenizer = tokenizer;
+  }
+
+  /// Reset the Tokenizer instance to use the default implementation
+  /// crated by the package
+  void setWordTokenizerToDefault() {
+    verifyState();
+    _wordTokenizer = WordTokenizer();
   }
 
   void _initLanguageCache(List<LanguageIdentifier> identifiers) {

--- a/lib/src/multi_spell_checker.dart
+++ b/lib/src/multi_spell_checker.dart
@@ -44,10 +44,10 @@ CacheObject<Map<String, int>>? _cacheWordDictionary;
 class MultiSpellChecker extends Checker<List<String>, List<String>>
     implements CheckOperationsStreams<List<TextSpan>> {
   List<LanguageIdentifier>? customLanguages;
-  late Tokenizer<String> _wordTokenizer;
+  late Tokenizer<List<String>> _wordTokenizer;
   MultiSpellChecker({
     required super.language,
-    Tokenizer<String>? wordTokenizer,
+    Tokenizer<List<String>>? wordTokenizer,
     super.safeDictionaryLoad,
     super.worksWithoutDictionary,
     super.caseSensitive = false,
@@ -403,7 +403,7 @@ class MultiSpellChecker extends Checker<List<String>, List<String>>
   }
 
   /// Set a new cusotm Tokenizer instance to be used by the package
-  void setNewTokenizer(Tokenizer<String> tokenizer) {
+  void setNewTokenizer(Tokenizer<List<String>> tokenizer) {
     verifyState();
     _wordTokenizer = tokenizer;
   }

--- a/lib/src/simple_spell_checker.dart
+++ b/lib/src/simple_spell_checker.dart
@@ -49,10 +49,10 @@ class SimpleSpellChecker extends Checker<String, String>
   ///
   /// Note: [words] param must be have every element separated by a new line
   List<LanguageIdentifier>? customLanguages;
-  late Tokenizer<String> _wordTokenizer;
+  late Tokenizer<List<String>> _wordTokenizer;
   SimpleSpellChecker({
     required super.language,
-    Tokenizer<String>? wordTokenizer,
+    Tokenizer<List<String>>? wordTokenizer,
     super.safeDictionaryLoad,
     super.worksWithoutDictionary,
     bool autoAddLanguagesFromCustomDictionaries = false,
@@ -408,7 +408,7 @@ class SimpleSpellChecker extends Checker<String, String>
   }
 
   /// Set a new cusotm Tokenizer instance to be used by the package
-  void setNewTokenizer(Tokenizer<String> tokenizer) {
+  void setNewTokenizer(Tokenizer<List<String>> tokenizer) {
     verifyState();
     _wordTokenizer = tokenizer;
   }

--- a/lib/src/spell_checker_interface/abtract_checker.dart
+++ b/lib/src/spell_checker_interface/abtract_checker.dart
@@ -7,9 +7,7 @@ import 'package:simple_spell_checker/src/spell_checker_interface/mixin/disposabl
 import '../common/cache_object.dart';
 import '../common/language_identifier.dart';
 import '../common/strategy_language_search_order.dart';
-import '../common/tokenizer.dart';
 import '../utils.dart';
-import '../word_tokenizer.dart';
 import 'mixin/check_ops.dart';
 
 /// add a cache var let us add any custom language
@@ -33,9 +31,6 @@ abstract class Checker<T extends Object, R>
   /// ignores if the dictionary or language is not founded
   late bool _worksWithoutDictionary;
 
-  /// Decides how the text will be divided and if the text could be tokenized
-  late Tokenizer _wordTokenizer;
-
   final bool caseSensitive;
 
   /// the state of SimpleSpellChecker and to store to a existent language with its dictionary
@@ -54,7 +49,6 @@ abstract class Checker<T extends Object, R>
   final StreamController<T?> _languageState = StreamController.broadcast();
   Checker({
     required T language,
-    Tokenizer? wordTokenizer,
     bool safeDictionaryLoad = false,
     bool worksWithoutDictionary = false,
     List<String> whiteList = const [],
@@ -64,7 +58,6 @@ abstract class Checker<T extends Object, R>
   }) {
     initializeChecker(
       language: language,
-      wordTokenizer: wordTokenizer,
       whiteList: whiteList,
       safeDictionaryLoad: safeDictionaryLoad,
       worksWithoutDictionary: worksWithoutDictionary,
@@ -73,9 +66,6 @@ abstract class Checker<T extends Object, R>
       strategy: strategy,
     );
   }
-
-  @protected
-  Tokenizer get wordTokenizer => _wordTokenizer;
 
   @protected
   bool get safeDictionaryLoad => _safeDictionaryLoad;
@@ -114,6 +104,14 @@ abstract class Checker<T extends Object, R>
     _whiteList.addAll(words);
   }
 
+  /// [initDictionary] is a method used when the dictionary need to be
+  /// loaded before of use it on [check()] functions
+  ///
+  /// Here we can place all necessary logic to initalize an valid directionary
+  /// used by [isWordValid] method
+  ///
+  /// You can use [defaultLanguagesDictionarie] that correspond with the current
+  /// languages implemented into the package
   @protected
   void initDictionary(String words);
 
@@ -172,7 +170,6 @@ abstract class Checker<T extends Object, R>
   @protected
   void initializeChecker({
     required T language,
-    Tokenizer? wordTokenizer,
     List<String> whiteList = const [],
     bool safeDictionaryLoad = false,
     bool worksWithoutDictionary = false,
@@ -189,7 +186,6 @@ abstract class Checker<T extends Object, R>
     _safeDictionaryLoad = safeDictionaryLoad;
     _worksWithoutDictionary = worksWithoutDictionary;
     this.strategy = strategy;
-    _wordTokenizer = wordTokenizer ?? WordTokenizer();
     reloadDictionarySync();
   }
 
@@ -229,19 +225,6 @@ abstract class Checker<T extends Object, R>
   void setNewStrategy(StrategyLanguageSearchOrder strategy) {
     verifyState();
     this.strategy = strategy;
-  }
-
-  /// Set a new cusotm Tokenizer instance to be used by the package
-  void setNewTokenizer(Tokenizer tokenizer) {
-    verifyState();
-    _wordTokenizer = tokenizer;
-  }
-
-  /// Reset the Tokenizer instance to use the default implementation
-  /// crated by the package
-  void setWordTokenizerToDefault() {
-    verifyState();
-    _wordTokenizer = WordTokenizer();
   }
 
   /// toggle the state of the checking

--- a/lib/src/spell_checker_interface/mixin/stream_checks.dart
+++ b/lib/src/spell_checker_interface/mixin/stream_checks.dart
@@ -1,12 +1,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
-mixin CheckOperations<T extends Object, R> {
-  bool isWordValid(String word);
-  Future<void> reloadDictionary();
-  bool checkLanguageRegistry(R language);
-  void reloadDictionarySync();
-  T? check(
+mixin CheckOperationsStreams<T extends Object> {
+  Stream<T?> checkStream(
     String text, {
     TextStyle? wrongStyle,
     TextStyle? commonStyle,
@@ -14,7 +10,7 @@ mixin CheckOperations<T extends Object, R> {
         customLongPressRecognizerOnWrongSpan,
   });
 
-  List<O>? checkBuilder<O>(
+  Stream<List<O>> checkBuilderStream<O>(
     String text, {
     required O Function(String, bool) builder,
   });

--- a/lib/src/word_tokenizer.dart
+++ b/lib/src/word_tokenizer.dart
@@ -1,7 +1,7 @@
 import 'package:simple_spell_checker/src/common/tokenizer.dart';
 
 /// Default work tokenizer implemented by the package
-class WordTokenizer extends Tokenizer {
+class WordTokenizer extends Tokenizer<String> {
   WordTokenizer({
     super.separatorRegExp,
   });
@@ -13,12 +13,7 @@ class WordTokenizer extends Tokenizer {
 
   /// Divides a string into words
   @override
-  List<String> tokenize(
-    String content, {
-    @Deprecated(
-        'removeAllEmptyWords are no longer used and will be removed in future releases')
-    bool removeAllEmptyWords = false,
-  }) {
+  List<String> tokenize(String content) {
     final List<String> words = (separatorRegExp ?? defaultSeparatorRegExp)
         .allMatches(content)
         .map(

--- a/lib/src/word_tokenizer.dart
+++ b/lib/src/word_tokenizer.dart
@@ -1,7 +1,7 @@
 import 'package:simple_spell_checker/src/common/tokenizer.dart';
 
 /// Default work tokenizer implemented by the package
-class WordTokenizer extends Tokenizer<String> {
+class WordTokenizer extends Tokenizer<List<String>> {
   WordTokenizer({
     super.separatorRegExp,
   });


### PR DESCRIPTION
## What's changed?

* Moved check streams method to `CheckOperationsStreams` instead to be into `CheckOperations` (them are now implemented by default in `MultiSpellChecker` and `SimpleSpellChecker`).
* `Tokenizer` class now works with generic types.
* removed `wordTokenizer` param from base class `Checker` to allow devs implement it if they want it.
* More documentation about how use `initDictionary` method.