### PR TITLE
Chore: deprecated members of `Checker` and `SimpleSpellChecker` and adapted them to future PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,6 @@
 
 **Simple Spell Checker** is a simple but powerful spell checker, that allows to all developers detect and highlight spelling errors in text. The package also allows customization of languages, providing efficient and adaptable spell-checking for various applications.
 
-## Use with caution
-
-**Simple Spell Checker** is a client-side dependency that works without any need for an internet connection, so, it could weigh more than expected due to each of the dictionaries. As mentioned below, it supports a very wide variety of languages which can have a file of up to 300.000 words (this being just one language, since there are others such as Russian that contain up to 400.000 words), which makes the package increase in size more than expected. If you want to avoid your application increasing in size significantly, the best thing you can do is use the native solution [DefaultSpellCheckService](https://api.flutter.dev/flutter/services/DefaultSpellCheckService-class.html) to avoid this.
-
-## Features
-
-- **Real-time Spell Checking**: Split text into spans with correct and incorrect words, highlighting errors dynamically.
-- **Custom Language Support**: Add custom dictionaries for languages not included by default.
-- **Caching for Performance**: Automatically caches dictionaries and languages to avoid reloading large text files.
-- **Customizable Error Handling**: Optionally use custom gesture recognizers for wrong words, enabling custom interactions.
-- **Stream-based State Management**: Provides a stream of updates for spell-checking states, allowing reactive UI updates.
-
 ## Current languages supported
 
 The package already have a default list of words for these languages:
@@ -61,46 +49,7 @@ import 'package:simple_spell_checker/simple_spell_checker.dart';
 
 SimpleSpellChecker spellChecker = SimpleSpellChecker(
    language: 'en', // the current language that the user is using
-   // if we have a current custom language and it is not found into the custom languages this value is used
-   safeLanguageName: 'es', 
-   // avoid throws UnSupportedError if a custom language is not founded
-   safeDictionaryLoad: true,  
-   // if the language if not founded creates an empty instance to replace the not founded lan
-   worksWithoutDictionary: true, 
-   // byPackage | byUser -> defines if the language need to be searched first in customLanguages or in the default ones
-   strategy: StrategyLanguageSearchOrder.byPackage, 
-   // this is a list of words that will be ignored by check ops
    whiteList: <String>[],  
-   customLanguages: <LanguageIdentifier>[],
-   // if is true, will take all languages into [customLanguages] to add them to the registry
-   autoAddLanguagesFromCustomDictionaries: false,
-   caseSensitive: false,
-);
-```
-
-### MultiSpellChecker 
-
-`MultiSpellChecker` is a instance of the same type of `SimpleSpellChecker` but this one let us add multiple languages to be checked in real-time.
-
- ```dart
-import 'package:simple_spell_checker/simple_spell_checker.dart';
-
-MultiSpellChecker spellChecker = MultiSpellChecker(
-   // the current languages that the user is using and correspond with english, russian, italian, and british english
-   language: ['en', 'ru', 'it', 'en-gb'], 
-   // if we have a current custom language and it is not found into the custom languages this value is used
-   safeLanguageName: 'en', 
-   // avoid throws UnSupportedError if a custom language is not founded
-   safeDictionaryLoad: true,  
-   // if the language if not founded creates an empty instance to replace the not founded lan
-   worksWithoutDictionary: true, 
-   // byPackage | byUser -> defines if the language need to be searched first in customLanguages or in the default ones
-   strategy: StrategyLanguageSearchOrder.byPackage, 
-   // this is a list of words that will be ignored by check ops
-   whiteList: [],  
-   customLanguages: <LanguageIdentifier>[],
-   // if is true, will take all languages into [customLanguages] to add them to the registry
-   autoAddLanguagesFromCustomDictionaries: false,
    caseSensitive: false,
 );
 ```
@@ -162,53 +111,11 @@ class CustomWordTokenizer extends Tokenizer<List<String>> {
 }
 ```
 
-## Handling Custom Languages:
-
-Add and use `addCustomLanguage()` by updating the `customLanguages` parameter:
-
-### SimpleSpellChecker
-
-```dart
-// You dictionary should be a string splitted by new lines
-// since this is the current format supported 
-//
-// Note: this could change in future releases
-final LanguageIdentifier identifier = LanguageIdentifier(language: 'custom_lang', words: '<your_dictionary>');
-// this need to be called for cases when we check if the language into the Spellchecker is already registered
-// then, if the language on SimpleSpellChecker
-spellChecker.registerLanguage(identifier.language);
-// this method add new custom language to the current ones
-// with it's own custom dictionary
-spellChecker.addCustomLanguage(identifier);
-// to set this new custom language to the state of the [SimpleSpellChecker] then use:
-spellChecker.setNewLanguageToState(identifier.language);
-```
-
-### MultiSpellChecker
-
-```dart
-final LanguageIdentifier identifier = LanguageIdentifier(language: 'custom_lang', words: '<your_dictionary>');
-// this need to be called for cases when we check if the language into the Spellchecker is already registered
-// then, if the language on SimpleSpellChecker
-spellChecker.registerLanguage(identifier.language);
-// this method to update the state automatically adding this 
-// new language identifier to the current languages in the state
-spellChecker.addCustomLanguage(identifier);
-```
-
-### Note:
-
-When you add a custom language you will need to call `registerLanguage()` and pass the language id to avoid throw an `UnSupportedError` in `check()` or `checkBuilder()` method since it always check if the current state of the language/languages, is/are already registered with the other ones.
-
 ## Additional Information
 
 ### Language Management
 
 * **setNewLanguageToState(String language)**: override the current language into the Spell Checker. _Only available for `SimpleSpellChecker` instances_
-* **setNewLanguageToCurrentLanguages(String language)**: add the language to the current ones into the Spell Checker. _Only available for `MultiSpellChecker` instances_
-* **setNewLanState(List languages)**: override the current languages into the Spell Checker. _Only available for `MultiSpellChecker` instances_
-* **registerLanguage(String language)**: Add a new language to the registries (the registry is a different instance that the current languages that contains all languages available and is used in `check()` methods to avoid check if the language is not available _however, this is overrided if `worksWithoutDictionary` is true_).
-* **updateCustomLanguageIfExist(LanguageIdentifier language, bool withException)**: override the current value if exist in `customLanguages` var.
 * **reloadDictionarySync()**: Reload the dictionary synchronously to update the language or dictionary.
 
 ### White List Management
@@ -220,71 +127,18 @@ When you add a custom language you will need to call `registerLanguage()` and pa
 ### State Management 
 
 * **toggleChecker()**: activate or deactivate the spell checking. If it is deactivate `check()` methods always will return null 
-* **isCheckerActive()**: return the state of the spell checker.
+* **isActiveChecking()**: return the state of the spell checker.
 
 ### Customization Options
 
 * **checkBuilder**: Use the `checkBuilder()` method for a custom widget-based approach to handling spelling errors.
-* **setNewStrategy**: Use the `setNewStrategy()` method to modify the current value to change the behvarior if the dictionary is reloaded.
 * **customLongPressRecognizerOnWrongSpan**: Attach custom gesture recognizers to wrong words for tailored interactions.
-
-### Caching
-
-The package uses caching mechanisms to store loaded dictionaries and languages, significantly reducing the load time when checking large texts. The cache mechanisms share the same instances used by both type of the Spell Checkers (`SimpleSpellChecker` and `MultiSpellChecker`).
-
-* **Language Caching**: The package caches language identifiers and word dictionaries to avoid reloading them multiple times, which is particularly useful for large dictionaries.
-* **Custom Language Caching**: When adding custom languages, they are cached automatically to improve performance.
 
 ### Stream Updates
 
 The `SimpleSpellChecker` class provides a stream (stream getter) that broadcasts updates whenever the spell-checker state changes (by now, we just pass the current state of the object list that is always updated when add a new object). This is useful for reactive UI updates.
 
-#### Native methods streams without using `StreamController`
-
-Use the `checkStream()` or `checkBuilderStream<T>()` method to analyze a `String` for spelling errors:
-
-_Note: this functions let us dispose the controllers using `disposeControllers()` without lost the realtime functionality_.
-
-```dart
-late StreamSubscription subscription;
-subscription = spellChecker 
-   .checkStream(
-      'Your text here',
-      removeEmptyWordsOnTokenize: true,
-   )
-   .listen(
-      (List<TextSpan> data) {},
-);
-/// remenber call cancel
-subscription.cancel();
-```
-or 
-
-```dart
-late StreamSubscription subscription;
-subscription = spellChecker
-    .checkBuilderStream<Widget>(
-      'Your text here',
-      builder: (word, isWrong) {
-        return Text(word, style: TextStyle(color: isWrong ? Colors.red : null));
-      },
-  ).listen(
-    (List<Widget> data) {},
-);
-
-/// remenber call cancel
-subscription.cancel();
-```
-
-#### For listen the list of the widgets while is checking:
-
-```dart
-spellChecker.stream.listen((event) {
-  print("Spell check state updated.");
-});
-```
-
-For listen the changes of the language into SimpleSpellChecker:
+### For listen the changes of the language into SimpleSpellChecker:
 
 ```dart
 spellChecker.languageStream.listen((event) {
@@ -309,127 +163,3 @@ spellChecker.disposeControllers();
 ```
 
 It clears any cached data and closes the internal stream to prevent memory leaks.
-
-## You can create your custom `SpellChecker` extending it from `Checker` class
-
-As you now we create default implementation that can check your text without any issue (as we expect), but sometimes, we could need some different implementation from the default ones. By this, we can create our custom spell checker extending it from `Checker` class that contains all params and
-methods used by `MultiSpellChecker` or `SimpleSpellChecker`.
-
-```dart
-// if you want to add also the check streams ops
-// you ca implement the interface [CheckOperationsStreams]
-abstract class Checker<T extends Object, R, OP extends Object> with CheckOperations<OP, R>, Disposable, DisposableStreams {
-
-// params
-final Set<String> _whiteList = {};
-late T _language;
-
-/// if it is true the checker always will be return null
-bool _turnOffChecking = false;
-
-/// If the current language is not founded on [customLanguages] or default ones,
-/// then select one of the existent to avoid conflicts
-late bool _safeDictionaryLoad;
-
-/// If it is true then the spell checker
-/// ignores if the dictionary or language is not founded
-late bool _worksWithoutDictionary;
-
-final bool caseSensitive;
-
-/// the state of SimpleSpellChecker and to store to a existent language with its dictionary
-/// If _safeDictionaryLoad is true, this will be used as the default language to update
-final String safeLanguageName;
-StrategyLanguageSearchOrder strategy;
-
-/// decide if the checker is disposed
-bool _disposed = false;
-
-/// this just can be called on closeControllers
-bool _disposedControllers = false;
-
-final StreamController<Object?> _simpleSpellCheckerWidgetsState =
-    StreamController.broadcast();
-
-final StreamController<T?> _languageState = StreamController.broadcast();
-
-// methods
-
-@protected
-bool get safeDictionaryLoad => _safeDictionaryLoad;
-
-@protected
-bool get turnOffChecking => _turnOffChecking;
-
-@protected
-void setRegistryToDefault() => _languagesRegistry.set = {...defaultLanguages};
-
-@protected
-List<String> get languagesRegistry => List.unmodifiable(_languagesRegistry.get);
-
-/// This will return all the words contained on the current state of the dictionary
-T getCurrentLanguage() {
-   verifyState();
-   return _language;
-}
-
-@protected
-bool get worksWithoutDictionary => _worksWithoutDictionary;
-
-@protected
-void initDictionary(String words);
-
-void addCustomLanguage(LanguageIdentifier language);
-
-/// This method is already defined and doesn't need to be override
-/// since it is used to initialize the params into [Checker]
-void initializeChecker({...});
-
-/// Verify if [Checker] is not disposed yet
-@protected
-@mustCallSuper
-void verifyState();
-
-// these methods let us add new states to the [StreamControllers] 
-// and them are already defined
-@protected
-@mustCallSuper
-void addNewEventToLanguageState(T? language);
-
-@protected
-@mustCallSuper
-void addNewEventToWidgetsState(Object? object);
-
-// dispose methods
-@mustCallSuper
-void dispose();
-
-@mustCallSuper
-void disposeControllers();
-
-// methods from [CheckOperations] interface
-// that need to be implemented by the developer
-Future<void> reloadDictionary();
-bool isWordValid(String word);
-void reloadDictionarySync();
-bool checkLanguageRegistry(R language);
-OP? check(
-  String text, {
-  TextStyle? wrongStyle,
-  TextStyle? commonStyle,
-  LongPressGestureRecognizer Function(String)?
-      customLongPressRecognizerOnWrongSpan,
-});
-
-List<O>? checkBuilder<O>(
-  String text, {
-  required O Function(String, bool) builder,
-});
-}
-```
-
-## Contributions
-
-If you find a bug or want to add a new feature, please open an **issue** or submit a **pull request** on the [GitHub repository](https://github.com/CatHood0/simple_spell_checker/).
-
-This project is licensed under the **MIT License** - see the [LICENSE](https://github.com/CatHood0/simple_spell_checker/blob/Main/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Use the `checkBuilder<T>()` method to analyze a `String` for spelling errors and
 ```dart
 List<Widget>? result = spellChecker.checkBuilder<Widget>(
   'Your text here',
-  builder: (word, isWrong) {
-    return Text(word, style: TextStyle(color: isWrong ? Colors.red : null));
+  builder: (word, isValid) {
+    return Text(word, style: TextStyle(color: !isValid ? Colors.red : null));
   }
 );
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,7 +53,6 @@ class _MyHomePageState extends State<MyHomePage> {
       _controller = SpellCheckerController(
         spellchecker: SimpleSpellChecker(
           language: language,
-          safeDictionaryLoad: true,
         ),
         text:
             'Simple Spell Checker is a simple but powerful spell checker, that allows to all developers detect and highlight spelling errors in text. It Allows customization of languages, providing efficient and adaptable spell-checking for various applications.',
@@ -61,7 +60,6 @@ class _MyHomePageState extends State<MyHomePage> {
       _titleController = SpellCheckerController(
         spellchecker: SimpleSpellChecker(
           language: language,
-          safeDictionaryLoad: true,
         ),
         text: 'What is Simple Spell Checker',
       );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,18 +79,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -119,18 +119,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
 sdks:
   dart: ">=3.4.3 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/common/language_identifier.dart
+++ b/lib/src/common/language_identifier.dart
@@ -1,28 +1,13 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show immutable;
 
 /// [LanguageIdentifier] is a representation of a register of a language with it's dictionary
 ///   [language] ref to the country code
 ///   [word] ref to the dictionary
-///
-/// [words] dictionary must have a plain text format where the new lines separate every word
-///
-/// # Example:
-/// it language should have a dictionary format like:
-///
-/// italia
-/// miniatura
-/// famiglia
-/// specie
-/// europa
-/// latino
-/// animalia
-/// roma
-///
-/// Making simple and easier add custom dictionaries for everyone
 @immutable
 class LanguageIdentifier {
   final String language;
-  final String words;
+  final Map<String, int> words;
 
   const LanguageIdentifier({
     required this.language,
@@ -31,18 +16,22 @@ class LanguageIdentifier {
 
   LanguageIdentifier copyWith({
     String? language,
+    @Deprecated(
+        'words is no longer used since words is map type. Use wordsMap instead')
     String? words,
+    Map<String, int>? wordsMap,
   }) {
     return LanguageIdentifier(
       language: language ?? this.language,
-      words: words ?? this.words,
+      words: wordsMap ?? this.words,
     );
   }
 
   @override
   bool operator ==(covariant LanguageIdentifier other) {
     if (identical(this, other)) return true;
-    return language == other.language && words == other.words;
+    return language == other.language &&
+        const DeepCollectionEquality().equals(words, other.words);
   }
 
   @override

--- a/lib/src/common/language_identifier.dart
+++ b/lib/src/common/language_identifier.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show immutable;
 ///   [language] ref to the country code
 ///   [word] ref to the dictionary
 @immutable
+@Deprecated('LanguageIdentifier is no longer used and will be removed in future releases.')
 class LanguageIdentifier {
   final String language;
   final Map<String, int> words;

--- a/lib/src/common/strategy_language_search_order.dart
+++ b/lib/src/common/strategy_language_search_order.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 /// This tells to the [SimpleSpellchecker] which should be the priority
 /// when we need to search the dictionary for the current language
 @experimental
+@Deprecated('StrategyLanguageSearchOrder is no longer used and will be removed in future releases.')
 enum StrategyLanguageSearchOrder {
   // Will search first if the language implementation is into the
   // custom languages

--- a/lib/src/common/strategy_language_search_order.dart
+++ b/lib/src/common/strategy_language_search_order.dart
@@ -1,5 +1,8 @@
+import 'package:meta/meta.dart';
+
 /// This tells to the [SimpleSpellchecker] which should be the priority
 /// when we need to search the dictionary for the current language
+@experimental
 enum StrategyLanguageSearchOrder {
   // Will search first if the language implementation is into the
   // custom languages

--- a/lib/src/multi_spell_checker.dart
+++ b/lib/src/multi_spell_checker.dart
@@ -1,17 +1,10 @@
 import 'dart:async' show Stream, StreamController;
-import 'dart:convert' show LineSplitter;
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show LongPressGestureRecognizer;
-import 'package:flutter/material.dart'
-    show Colors, TextDecoration, TextDecorationStyle, TextSpan, TextStyle;
+import 'package:flutter/material.dart';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show LanguageIdentifier, isWordHasNumber;
-import 'package:simple_spell_checker/src/common/extensions.dart';
-import 'package:simple_spell_checker/src/common/strategy_language_search_order.dart';
+    show LanguageIdentifier;
 import 'package:simple_spell_checker/src/spell_checker_interface/abtract_checker.dart';
 import 'package:simple_spell_checker/src/spell_checker_interface/mixin/stream_checks.dart';
-import 'package:simple_spell_checker/src/utils.dart'
-    show defaultLanguagesDictionaries, isWordHasNumber;
 import 'package:simple_spell_checker/src/word_tokenizer.dart';
 import 'common/cache_object.dart' show CacheObject;
 import 'common/tokenizer.dart';
@@ -41,11 +34,13 @@ CacheObject<Map<String, int>>? _cacheWordDictionary;
 // [setNewLanguage] method to override the current language from the class
 // second:
 // [reloadDictionary] or [reloadDictionarySync] methods to set a new state to the directionary
-
+@Deprecated(
+    'MultiSpellChecker should not be used and will be removed in future releases.')
 class MultiSpellChecker
     extends Checker<List<String>, List<String>, List<TextSpan>>
     implements CheckOperationsStreams<List<TextSpan>> {
   List<LanguageIdentifier>? customLanguages;
+  // ignore: unused_field
   late Tokenizer<List<String>> _wordTokenizer;
   MultiSpellChecker({
     required super.language,
@@ -77,15 +72,7 @@ class MultiSpellChecker
   }
 
   @protected
-  void registryLanguagesFromCustomDictionaries() {
-    verifyState();
-    customLanguages ??= [];
-    for (var identifier in customLanguages!) {
-      if (!languagesRegistry.contains(identifier.language)) {
-        registerLanguage(identifier.language);
-      }
-    }
-  }
+  void registryLanguagesFromCustomDictionaries() {}
 
   /// Check if your line wrong words
   ///
@@ -100,58 +87,7 @@ class MultiSpellChecker
     LongPressGestureRecognizer Function(String)?
         customLongPressRecognizerOnWrongSpan,
   }) {
-    addNewEventToWidgetsState(null);
-    if (turnOffChecking) {
-      return null;
-    }
-    verifyState();
-    if (_cacheLanguageIdentifiers == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
-      throw UnsupportedError(
-          'The ${getCurrentLanguage()} are not supported or registered on the [customLanguages]. Please, first add your new language using [registerLanguage] and after add the language identifier using [addCustomLanguage] to avoid this message.');
-    }
-    if (!_wordTokenizer.canTokenizeText(text)) return null;
-    final spans = <TextSpan>[];
-    final words = _wordTokenizer.tokenize(text);
-    for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i).toString();
-      final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
-      if (isWordHasNumber(word) ||
-          isWordValid(word) ||
-          word.contains(' ') ||
-          word.noWords) {
-        if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex).toString();
-          if (nextWord.contains(' ')) {
-            spans.add(TextSpan(text: '$word$nextWord', style: commonStyle));
-            // ignore the next since it was already passed
-            i++;
-            continue;
-          }
-        }
-        spans.add(TextSpan(text: word, style: commonStyle));
-      } else if (!isWordValid(word)) {
-        final longTap = customLongPressRecognizerOnWrongSpan?.call(word);
-        spans.add(
-          TextSpan(
-            text: word,
-            recognizer: longTap,
-            style: wrongStyle ??
-                const TextStyle(
-                  decorationColor: Colors.red,
-                  decoration: TextDecoration.underline,
-                  decorationStyle: TextDecorationStyle.wavy,
-                  decorationThickness: 1.75,
-                ),
-          ),
-        );
-      }
-      addNewEventToWidgetsState(spans);
-    }
-    return [...spans];
+    return [];
   }
 
   /// Check spelling in realtime
@@ -167,58 +103,7 @@ class MultiSpellChecker
     LongPressGestureRecognizer Function(String)?
         customLongPressRecognizerOnWrongSpan,
   }) async* {
-    if (turnOffChecking) {
-      yield [];
-    }
-    verifyState();
-    if (_cacheLanguageIdentifiers == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
-      yield [];
-    }
-    if (!_wordTokenizer.canTokenizeText(text)) yield [];
-    final spans = <TextSpan>[];
-    final words = _wordTokenizer.tokenize(text);
-    for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i).toString();
-      final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
-      if (isWordHasNumber(word) ||
-          isWordValid(word) ||
-          word.contains(' ') ||
-          word.noWords) {
-        if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex).toString();
-          if (nextWord.contains(' ')) {
-            spans.add(TextSpan(text: '$word$nextWord', style: commonStyle));
-            yield [...spans];
-            // ignore the next since it was already passed
-            i++;
-            continue;
-          }
-        }
-        spans.add(TextSpan(text: word, style: commonStyle));
-        yield [...spans];
-      } else if (!isWordValid(word)) {
-        final longTap = customLongPressRecognizerOnWrongSpan?.call(word);
-        spans.add(
-          TextSpan(
-            text: word,
-            recognizer: longTap,
-            style: wrongStyle ??
-                const TextStyle(
-                  decorationColor: Colors.red,
-                  decoration: TextDecoration.underline,
-                  decorationStyle: TextDecorationStyle.wavy,
-                  decorationThickness: 1.75,
-                ),
-          ),
-        );
-        yield [...spans];
-      }
-    }
-    yield [...spans];
+    yield [];
   }
 
   /// a custom implementation for check if your line wrong words and return a custom list of widgets
@@ -229,46 +114,7 @@ class MultiSpellChecker
     String text, {
     required O Function(String, bool) builder,
   }) {
-    addNewEventToWidgetsState(null);
-    if (turnOffChecking) {
-      return null;
-    }
-    verifyState();
-
-    if (_cacheLanguageIdentifiers == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
-      throw UnsupportedError(
-          'The ${getCurrentLanguage()} are not supported or registered on the [customLanguages]. Please, first add your new language using [registerLanguage] and after add the language identifier using [addCustomLanguage] to avoid this message.');
-    }
-    if (!_wordTokenizer.canTokenizeText(text)) return null;
-    final spans = <O>[];
-    final words = _wordTokenizer.tokenize(text);
-    for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i).toString();
-      final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
-      if (isWordHasNumber(word) ||
-          isWordValid(word) ||
-          word.contains(' ') ||
-          word.noWords) {
-        if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex).toString();
-          if (nextWord.contains(' ')) {
-            spans.add(builder.call('$word$nextWord', true));
-            // ignore the next since it was already passed
-            i++;
-            continue;
-          }
-        }
-        spans.add(builder.call(word, true));
-      } else if (!isWordValid(word)) {
-        spans.add(builder.call(word, false));
-      }
-      addNewEventToWidgetsState(spans);
-    }
-    return [...spans];
+    return null;
   }
 
   /// a custom implementation that let us subcribe to it and listen
@@ -284,47 +130,7 @@ class MultiSpellChecker
     String text, {
     required T Function(String, bool) builder,
   }) async* {
-    if (turnOffChecking) {
-      yield [];
-    }
-    verifyState();
-    if (_cacheLanguageIdentifiers == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
-      throw UnsupportedError(
-          'The ${getCurrentLanguage()} are not supported or registered on the [customLanguages]. Please, first add your new language using [registerLanguage] and after add the language identifier using [addCustomLanguage] to avoid this message.');
-    }
-    if (!_wordTokenizer.canTokenizeText(text)) yield [];
-    final spans = <T>[];
-    final words = _wordTokenizer.tokenize(text);
-    for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i).toString();
-      final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
-      if (isWordHasNumber(word) ||
-          isWordValid(word) ||
-          word.contains(' ') ||
-          word.noWords) {
-        if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex).toString();
-          if (nextWord.contains(' ')) {
-            spans.add(builder.call('$word$nextWord', true));
-            yield [...spans];
-            // ignore the next since it was already passed
-            i++;
-            continue;
-          }
-        }
-
-        spans.add(builder.call(word, true));
-        yield [...spans];
-      } else if (!isWordValid(word)) {
-        spans.add(builder.call(word, false));
-        yield [...spans];
-      }
-    }
-    yield [...spans];
+    yield [];
   }
 
   /// Check if the word are registered on the dictionary
@@ -334,93 +140,22 @@ class MultiSpellChecker
   @override
   @protected
   bool isWordValid(String word) {
-    // if word is just an whitespace then is not wrong
-    if (word.trim().isEmpty) return true;
-    if (whiteList.contains(word)) return true;
-    verifyState(alsoCache: true);
-    final wordsMap = _cacheWordDictionary?.get ?? {};
-    final newWordWithCaseSensitive =
-        caseSensitive ? word.toLowerCaseFirst() : word.trim().toLowerCase();
-    final int? validWord = wordsMap[newWordWithCaseSensitive];
-    return validWord != null;
+    return false;
   }
 
   (bool, LanguageIdentifier?) _customContainsLanguage(String lan) {
-    customLanguages ??= [];
-    for (var language in customLanguages!) {
-      if (language.language == lan) return (true, language);
-    }
     return (false, null);
   }
 
   @override
-  void reloadDictionarySync() async {
-    verifyState();
-    _cacheLanguageIdentifiers = null;
-    // check if the current language is not registered already
-    final List<LanguageIdentifier> dictionaries = [];
-    for (var lan in getCurrentLanguage()) {
-      final defaultDictionary = defaultLanguagesDictionaries[lan];
-      if (strategy == StrategyLanguageSearchOrder.byUser ||
-          defaultDictionary == null) {
-        final (customContainsLan, identifier) = _customContainsLanguage(lan);
-        if (customContainsLan) {
-          dictionaries.add(identifier!);
-          continue;
-        } else if (!customContainsLan &&
-            worksWithoutDictionary &&
-            safeDictionaryLoad) {
-          dictionaries.add(LanguageIdentifier(
-              language: lan, words: identifier?.words ?? ''));
-          continue;
-        } else {
-          if (safeDictionaryLoad) {
-            final defaultSafeDictionary =
-                defaultLanguagesDictionaries[safeLanguageName] ?? '';
-            if (defaultSafeDictionary.isNotEmpty) {
-              dictionaries.add(
-                LanguageIdentifier(
-                  language: safeLanguageName,
-                  words: defaultSafeDictionary,
-                ),
-              );
-              continue;
-            }
-          }
-          throw UnsupportedError(
-            'The $lan is not supported by default and it wasnt founded on your [customLanguages]. We recommend always add first your custom LanguageIdentifier and after set your custom language to avoid this type of errors.',
-          );
-        }
-      } else {
-        dictionaries.add(
-          LanguageIdentifier(
-            language: lan,
-            words: defaultDictionary,
-          ),
-        );
-      }
-    }
-    _initLanguageCache(dictionaries);
-    initDictionary('');
-  }
+  void reloadDictionarySync() async {}
 
   /// Set a new cusotm Tokenizer instance to be used by the package
-  void setNewTokenizer(Tokenizer<List<String>> tokenizer) {
-    verifyState();
-    _wordTokenizer = tokenizer;
-  }
+  void setNewTokenizer(Tokenizer<List<String>> tokenizer) {}
 
   /// Reset the Tokenizer instance to use the default implementation
   /// crated by the package
-  void setWordTokenizerToDefault() {
-    verifyState();
-    _wordTokenizer = WordTokenizer();
-  }
-
-  void _initLanguageCache(List<LanguageIdentifier> identifiers) {
-    _cacheLanguageIdentifiers ??= CacheObject(object: []);
-    _cacheLanguageIdentifiers!.set = identifiers;
-  }
+  void setWordTokenizerToDefault() {}
 
   @override
   @protected
@@ -440,25 +175,7 @@ class MultiSpellChecker
 
   @override
   @protected
-  void initDictionary(String words) {
-    _cacheWordDictionary = CacheObject(object: {});
-    for (var identifier in _cacheLanguageIdentifiers!.get) {
-      final lanWords = identifier.words;
-      final Iterable<MapEntry<String, int>> entries =
-          const LineSplitter().convert(lanWords).map(
-                (element) => MapEntry(
-                  element.trim().toLowerCase(),
-                  1,
-                ),
-              );
-      final Map<String, int> wordsMap = {};
-      wordsMap.addEntries(entries);
-      _cacheWordDictionary!.set = {
-        ..._cacheWordDictionary!.get,
-        ...wordsMap,
-      };
-    }
-  }
+  void initDictionary(String words) {}
 
   @override
   void dispose({bool closeDictionary = false}) {
@@ -486,41 +203,13 @@ class MultiSpellChecker
   @override
   @protected
   bool checkLanguageRegistry(List<String> language) {
-    verifyState();
-    for (var lan in language) {
-      if (!languagesRegistry.contains(lan)) {
-        return false;
-      }
-    }
     return true;
   }
 
   @override
-  void addCustomLanguage(LanguageIdentifier language) {
-    verifyState();
-    customLanguages ??= [];
-    if (!customLanguages!.contains(language)) {
-      customLanguages?.add(language);
-      if (!getCurrentLanguage().contains(language.language)) {
-        setNewLanguageToState([language.language, ...getCurrentLanguage()]);
-      }
-    }
-  }
+  void addCustomLanguage(LanguageIdentifier language) {}
 
   /// search if the custom language exist and update if it is founded
   void updateCustomLanguageIfExist(LanguageIdentifier language,
-      [bool withException = true]) {
-    verifyState();
-    customLanguages ??= [];
-    if (!customLanguages!.contains(language)) {
-      if (!withException) return;
-      throw StateError(
-          'The identifier ${language.language} is not into customLanguages. Please consider add before use update operations');
-    }
-    int indexOf = customLanguages!
-        .indexWhere((element) => element.language == language.language);
-    if (indexOf != -1) {
-      customLanguages![indexOf] = language;
-    }
-  }
+      [bool withException = true]) {}
 }

--- a/lib/src/simple_spell_checker.dart
+++ b/lib/src/simple_spell_checker.dart
@@ -3,9 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show LongPressGestureRecognizer;
 import 'package:flutter/material.dart'
     show Colors, TextDecoration, TextDecorationStyle, TextSpan, TextStyle;
-import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show LanguageIdentifier;
 import 'package:simple_spell_checker/src/common/extensions.dart';
+import 'package:simple_spell_checker/src/common/language_identifier.dart';
 import 'package:simple_spell_checker/src/spell_checker_interface/abtract_checker.dart';
 import 'package:simple_spell_checker/src/utils.dart';
 import 'package:simple_spell_checker/src/word_tokenizer.dart';

--- a/lib/src/simple_spell_checker.dart
+++ b/lib/src/simple_spell_checker.dart
@@ -1,28 +1,16 @@
 import 'dart:async' show Stream, StreamController;
-import 'dart:convert' show LineSplitter;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show LongPressGestureRecognizer;
 import 'package:flutter/material.dart'
     show Colors, TextDecoration, TextDecorationStyle, TextSpan, TextStyle;
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show LanguageIdentifier, defaultLanguages, isWordHasNumber;
+    show LanguageIdentifier;
 import 'package:simple_spell_checker/src/common/extensions.dart';
 import 'package:simple_spell_checker/src/spell_checker_interface/abtract_checker.dart';
-import 'package:simple_spell_checker/src/spell_checker_interface/mixin/stream_checks.dart';
-import 'package:simple_spell_checker/src/utils.dart'
-    show defaultLanguages, defaultLanguagesDictionaries, isWordHasNumber;
+import 'package:simple_spell_checker/src/utils.dart';
 import 'package:simple_spell_checker/src/word_tokenizer.dart';
-import 'common/cache_object.dart' show CacheObject;
 import 'common/strategy_language_search_order.dart';
 import 'common/tokenizer.dart';
-
-const _noLanguage = LanguageIdentifier(language: 'no_lang', words: '');
-
-CacheObject<LanguageIdentifier>? _cacheLanguageIdentifier;
-
-/// add a cache var to avoid always reload all dictionary (it's a heavy task)
-/// and it is automatically reloaded when [_cacheLanguageIdentifier] change
-CacheObject<Map<String, int>>? _cacheWordDictionary;
 
 /// A simple spell checker that split on different spans
 /// the wrong words from the right ones.
@@ -30,50 +18,43 @@ CacheObject<Map<String, int>>? _cacheWordDictionary;
 /// SimpleSpellchecker automatically make a cache of the dictionary and languages
 /// to avoid always reload a bigger text file with too much words to be parsed to a valid
 /// format checking it.
-///
-/// This checker use a single language selector
-/// if you want to select multiple language instances
-/// use [MultiSpellChecker]
-//
-// if you want to update the language and the directory you will need to use
-//
-// first:
-// [setNewLanguage] method to override the current language from the class
-// second:
-// [reloadDictionary] or [reloadDictionarySync] methods to set a new state to the directionary
-
-class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
-    implements CheckOperationsStreams<List<TextSpan>> {
+class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
   /// By default we only have support for the most used languages
   /// but, we cannot cover all the cases. By this, you can use [customLanguages]
   /// adding the key of the language and your words
   ///
   /// Note: [words] param must be have every element separated by a new line
+  @Deprecated(
+      'customLanguages is no longer used and will be removed in future releases.')
   List<LanguageIdentifier>? customLanguages;
   late Tokenizer<List<String>> _wordTokenizer;
   SimpleSpellChecker({
     required super.language,
     Tokenizer<List<String>>? wordTokenizer,
-    super.safeDictionaryLoad,
-    super.worksWithoutDictionary,
-    bool autoAddLanguagesFromCustomDictionaries = false,
     List<String> whiteList = const [],
-    super.safeLanguageName,
     super.caseSensitive = false,
+    @Deprecated(
+        'safeLanguageName since customLanguages are no longer used and will be removed in future releases.')
+    super.safeLanguageName,
+    @Deprecated(
+        'autoAddLanguagesFromCustomDictionaries since customLanguages are no longer used and will be removed in future releases.')
+    bool autoAddLanguagesFromCustomDictionaries = false,
+    @Deprecated(
+        'safeDictionaryLoad is no longer used and will be removed in future releases.')
+    super.safeDictionaryLoad,
+    @Deprecated(
+        'worksWithoutDictionary is no longer used and will be removed in future releases.')
+    super.worksWithoutDictionary,
+    @Deprecated(
+        'strategy is no longer used and will be removed in future releases.')
     super.strategy = StrategyLanguageSearchOrder.byPackage,
+    @Deprecated(
+        'customLanguages is no longer used and will be removed in future releases.')
     this.customLanguages,
   }) {
-    _cacheWordDictionary = null;
-    _cacheLanguageIdentifier = null;
-    if (autoAddLanguagesFromCustomDictionaries) {
-      registryLanguagesFromCustomDictionaries();
-    }
     _wordTokenizer = wordTokenizer ?? WordTokenizer();
     initializeChecker(
       language: getCurrentLanguage(),
-      safeDictionaryLoad: safeDictionaryLoad,
-      worksWithoutDictionary: worksWithoutDictionary,
-      safeLanguageName: safeLanguageName,
       caseSensitive: caseSensitive,
     );
   }
@@ -91,16 +72,12 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
     LongPressGestureRecognizer Function(String)?
         customLongPressRecognizerOnWrongSpan,
   }) {
-    addNewEventToWidgetsState(null);
-    if (turnOffChecking) {
+    if (!isActiveChecking) {
       return null;
     }
     verifyState();
-    if (_cacheLanguageIdentifier == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
+
+    if (languagesToBeUsed[getCurrentLanguage()] == null) {
       return null;
     }
     if (!_wordTokenizer.canTokenizeText(text)) return null;
@@ -139,76 +116,8 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
           ),
         );
       }
-      addNewEventToWidgetsState(spans);
     }
     return [...spans];
-  }
-
-  /// Check spelling in realtime
-  ///
-  /// [removeEmptyWordsOnTokenize] this remove empty strings that was founded while splitting the text
-  /// [customLongPressRecognizerOnWrongSpan] let you add a custom recognizer for when you need to show suggestions
-  /// or make some custom action for wrong words
-  @override
-  Stream<List<TextSpan>> checkStream(
-    String text, {
-    TextStyle? wrongStyle,
-    TextStyle? commonStyle,
-    LongPressGestureRecognizer Function(String)?
-        customLongPressRecognizerOnWrongSpan,
-  }) async* {
-    if (turnOffChecking) {
-      yield [];
-    }
-    verifyState();
-    if (_cacheLanguageIdentifier == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
-      yield [];
-    }
-    if (!_wordTokenizer.canTokenizeText(text)) yield [];
-    final spans = <TextSpan>[];
-    final words = _wordTokenizer.tokenize(text);
-    for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i);
-      final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
-      if (isWordHasNumber(word) ||
-          isWordValid(word) ||
-          word.contains(' ') ||
-          word.noWords) {
-        if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex);
-          if (nextWord.contains(' ')) {
-            spans.add(TextSpan(text: '$word$nextWord', style: commonStyle));
-            yield [...spans];
-            // ignore the next since it was already passed
-            i++;
-            continue;
-          }
-        }
-        spans.add(TextSpan(text: word, style: commonStyle));
-        yield [...spans];
-      } else if (!isWordValid(word)) {
-        final longTap = customLongPressRecognizerOnWrongSpan?.call(word);
-        spans.add(
-          TextSpan(
-            text: word,
-            recognizer: longTap,
-            style: wrongStyle ??
-                const TextStyle(
-                  decorationColor: Colors.red,
-                  decoration: TextDecoration.underline,
-                  decorationStyle: TextDecorationStyle.wavy,
-                  decorationThickness: 1.75,
-                ),
-          ),
-        );
-        yield [...spans];
-      }
-    }
-    yield [...spans];
   }
 
   /// a custom implementation for check if your line wrong words and return a custom list of widgets
@@ -219,19 +128,13 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
     String text, {
     required O Function(String, bool) builder,
   }) {
-    addNewEventToWidgetsState(null);
-    if (turnOffChecking) {
+    if (!isActiveChecking) {
       return null;
     }
     verifyState();
-
-    if (_cacheLanguageIdentifier == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
+    if (languagesToBeUsed[getCurrentLanguage()] == null) {
       throw UnsupportedError(
-          'The ${getCurrentLanguage()} is not supported or registered as a custom language. Please, first add your new language using [addNewLanguage] and after add your [customLanguages] to avoid this message.');
+          'The ${getCurrentLanguage()} is not supported or registered. Please, first add your new language using [setLanguage] to avoid this message.');
     }
     if (!_wordTokenizer.canTokenizeText(text)) return null;
     final spans = <O>[];
@@ -256,65 +159,8 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
       } else if (!isWordValid(word)) {
         spans.add(builder.call(word, false));
       }
-      addNewEventToWidgetsState(spans);
     }
     return [...spans];
-  }
-
-  /// a custom implementation that let us subcribe to it and listen
-  /// all changes on realtime the list of wrong and right words
-  ///
-  /// # Note
-  /// By default, this stream not update the default [StreamController] of the spans
-  /// implemented in the class
-  ///
-  /// [removeEmptyWordsOnTokenize] this remove empty strings that was founded while splitting the text
-  @override
-  Stream<List<T>> checkBuilderStream<T>(
-    String text, {
-    required T Function(String, bool) builder,
-  }) async* {
-    if (turnOffChecking) {
-      yield [];
-    }
-    verifyState();
-    if (_cacheLanguageIdentifier == null) {
-      reloadDictionarySync();
-    }
-    if (!checkLanguageRegistry(getCurrentLanguage()) &&
-        !worksWithoutDictionary) {
-      throw UnsupportedError(
-          'The ${getCurrentLanguage()} is not supported or registered as a custom language. Please, first add your new language using [addNewLanguage] and after add your [customLanguages] to avoid this message.');
-    }
-    if (!_wordTokenizer.canTokenizeText(text)) yield [];
-    final spans = <T>[];
-    final words = _wordTokenizer.tokenize(text);
-    for (int i = 0; i < words.length; i++) {
-      final word = words.elementAt(i).toString();
-      final nextIndex = (i + 1) < words.length - 1 ? i + 1 : -1;
-      if (isWordHasNumber(word) ||
-          isWordValid(word) ||
-          word.contains(' ') ||
-          word.noWords) {
-        if (nextIndex != -1) {
-          final nextWord = words.elementAt(nextIndex);
-          if (nextWord.contains(' ')) {
-            spans.add(builder.call('$word$nextWord', true));
-            yield [...spans];
-            // ignore the next since it was already passed
-            i++;
-            continue;
-          }
-        }
-
-        spans.add(builder.call(word, true));
-        yield [...spans];
-      } else if (!isWordValid(word)) {
-        spans.add(builder.call(word, false));
-        yield [...spans];
-      }
-    }
-    yield [...spans];
   }
 
   /// Check if the word are registered on the dictionary
@@ -327,85 +173,12 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
     // if word is just an whitespace then is not wrong
     if (word.trim().isEmpty) return true;
     if (whiteList.contains(word)) return true;
-    verifyState(alsoCache: true);
-    final wordsMap = _cacheWordDictionary?.get ?? {};
+    verifyState();
+    final wordsMap = languagesToBeUsed[getCurrentLanguage()] ?? {};
     final newWordWithCaseSensitive =
         caseSensitive ? word.toLowerCaseFirst() : word.trim().toLowerCase();
     final int? validWord = wordsMap[newWordWithCaseSensitive];
-    return validWord != null;
-  }
-
-  /// this count about a accidental recursive calling
-  int _intoCount = 0;
-  @override
-  void reloadDictionarySync() async {
-    verifyState();
-    if (_cacheLanguageIdentifier?.get.language == getCurrentLanguage()) return;
-    // check if the current language is not registered already
-    if ((strategy == StrategyLanguageSearchOrder.byUser ||
-            !defaultLanguages.contains(getCurrentLanguage())) &&
-        _intoCount <= 2) {
-      final indexOf = customLanguages
-          ?.indexWhere((element) => element.language == getCurrentLanguage());
-      final invalidIndex = (indexOf == null || indexOf == -1);
-      if (invalidIndex && !safeDictionaryLoad) {
-        throw UnsupportedError(
-          'The ${getCurrentLanguage()} is not supported by default and was not founded on your [customLanguages]. We recommend always add first your custom LanguageIdentifier and after set your custom language to avoid this type of errors.',
-        );
-      } else if (invalidIndex && worksWithoutDictionary) {
-        setNewLanguageToState(_noLanguage.language);
-        _initLanguageCache(_noLanguage);
-        initDictionary(_noLanguage.words);
-        return;
-      } else if (invalidIndex &&
-          safeDictionaryLoad &&
-          !worksWithoutDictionary) {
-        setNewLanguageToState(safeLanguageName);
-        _intoCount++;
-        reloadDictionarySync();
-        return;
-      }
-      final LanguageIdentifier identifier =
-          customLanguages!.elementAt(indexOf!);
-      _initLanguageCache(identifier);
-      initDictionary(identifier.words);
-      return;
-    }
-    final dictionary = defaultLanguagesDictionaries[getCurrentLanguage()]!;
-    _intoCount = 0;
-    final identifier =
-        LanguageIdentifier(language: getCurrentLanguage(), words: dictionary);
-    _initLanguageCache(identifier);
-    initDictionary(identifier.words);
-  }
-
-  void _initLanguageCache(LanguageIdentifier identifier) {
-    _intoCount = 0;
-    if (_cacheWordDictionary == null) {
-      _cacheLanguageIdentifier = CacheObject(object: identifier);
-    } else {
-      _cacheLanguageIdentifier!.set = identifier;
-    }
-  }
-
-  @override
-  @protected
-  void initDictionary(String words) {
-    if (words.isEmpty) {
-      _cacheWordDictionary = CacheObject(object: {});
-      return;
-    }
-    final Iterable<MapEntry<String, int>> entries =
-        const LineSplitter().convert(words).map(
-              (element) => MapEntry(
-                element.trim().toLowerCase(),
-                1,
-              ),
-            );
-    final Map<String, int> wordsMap = {};
-    wordsMap.addEntries(entries);
-    _cacheWordDictionary ??= CacheObject(object: {});
-    _cacheWordDictionary!.set = {...wordsMap};
+    return validWord != null && validWord == 1;
   }
 
   /// Set a new cusotm Tokenizer instance to be used by the package
@@ -422,72 +195,124 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>>
   }
 
   @override
-  void dispose({bool closeDictionary = false}) {
+  void dispose({
+    @Deprecated(
+        'closeDictionary is no longer used and will be removed in future releases.')
+    bool closeDictionary = false,
+  }) {
     super.dispose();
-    if (closeDictionary) _cacheWordDictionary = null;
-    _cacheLanguageIdentifier = null;
   }
 
   /// This will return all the words contained on the current state of the dictionary
   Map<String, int>? getDictionary() {
     verifyState();
-    return _cacheWordDictionary?.get;
+    return languagesToBeUsed[getCurrentLanguage()];
   }
 
   @override
   @protected
-  void verifyState({bool alsoCache = false}) {
+  void verifyState({
+    @Deprecated(
+        'alsoCache is no longer used and will be removed in future releases.')
+    bool alsoCache = false,
+  }) {
     super.verifyState();
-    if (alsoCache) {
-      assert(_cacheWordDictionary != null);
-      assert(_cacheLanguageIdentifier != null);
-    }
+  }
+
+  static void setLanguage(String language, Map<String, int> words) {
+    assert(language.trim().isNotEmpty,
+        'language param cannot be empty or just contain whitespaces. Got [$language]');
+    languagesToBeUsed.addAll({language: words});
+  }
+
+  static void unlearnWord(String language, String word) {
+    assert(language.trim().isNotEmpty,
+        'language param cannot be empty or just contain whitespaces. Got [$language]');
+    if (!languagesToBeUsed.containsKey(language)) return;
+    final dictionary = languagesToBeUsed[language] ?? {};
+    dictionary.remove(word);
+    languagesToBeUsed[language] = dictionary;
+  }
+
+  static void learnWord(String language, String word) {
+    assert(language.trim().isNotEmpty,
+        'language param cannot be empty or just contain whitespaces. Got [$language]');
+    if (!languagesToBeUsed.containsKey(language)) return;
+    final dictionary = languagesToBeUsed[language] ?? {};
+    dictionary.addAll({word: 1});
+    languagesToBeUsed[language] = dictionary;
+  }
+
+  /// Check spelling in realtime
+  ///
+  /// [removeEmptyWordsOnTokenize] this remove empty strings that was founded while splitting the text
+  /// [customLongPressRecognizerOnWrongSpan] let you add a custom recognizer for when you need to show suggestions
+  /// or make some custom action for wrong words
+  @Deprecated(
+      'checkStream should not be used and will be removed on future releases.')
+  Stream<List<TextSpan>> checkStream(
+    String text, {
+    TextStyle? wrongStyle,
+    TextStyle? commonStyle,
+    LongPressGestureRecognizer Function(String)?
+        customLongPressRecognizerOnWrongSpan,
+  }) async* {
+    yield [];
+  }
+
+  /// a custom implementation that let us subcribe to it and listen
+  /// all changes on realtime the list of wrong and right words
+  ///
+  /// # Note
+  /// By default, this stream not update the default [StreamController] of the spans
+  /// implemented in the class
+  ///
+  /// [removeEmptyWordsOnTokenize] this remove empty strings that was founded while splitting the text
+  @Deprecated(
+      'checkBuilderStream should not be used and will be removed on future releases.')
+  Stream<List<T>> checkBuilderStream<T>(
+    String text, {
+    required T Function(String, bool) builder,
+  }) async* {
+    yield [];
   }
 
   @override
   @protected
+  @Deprecated(
+      'checkLanguageRegistry is no longer stable and should not be used. It will be removed in future releases.')
   bool checkLanguageRegistry(String language) {
-    verifyState();
-    return languagesRegistry.contains(language);
+    return true;
   }
 
   @override
-  void addCustomLanguage(LanguageIdentifier language) {
-    verifyState();
-    customLanguages ??= [];
-    if (!customLanguages!.contains(language)) {
-      customLanguages?.add(language);
-    }
-  }
+  @Deprecated(
+      'addCustomLanguage is no longer used and will be removed on future releases')
+  void addCustomLanguage(LanguageIdentifier language) {}
 
-  void updateCustomLanguageIfExist(LanguageIdentifier language) {
-    verifyState();
-    customLanguages ??= [];
-    if (!customLanguages!.contains(language)) {
-      throw StateError(
-          'The identifier ${language.language} is not into customLanguages. Please consider add before use update operations');
-    }
-    int indexOf = customLanguages!
-        .indexWhere((element) => element.language == language.language);
-    if (indexOf != -1) {
-      customLanguages![indexOf] = language;
-    }
-  }
+  @Deprecated(
+      'updateCustomLanguageIfExist is no longer used and will be removed on future releases')
+  void updateCustomLanguageIfExist(LanguageIdentifier language) {}
 
   @protected
-  void registryLanguagesFromCustomDictionaries() {
-    verifyState();
-    customLanguages ??= [];
-    for (var identifier in customLanguages!) {
-      if (!languagesRegistry.contains(identifier.language)) {
-        registerLanguage(identifier.language);
-      }
-    }
-  }
+  @Deprecated(
+      'registryLanguagesFromCustomDictionaries is no longer used and will be removed on future releases')
+  void registryLanguagesFromCustomDictionaries() {}
 
   @override
-  void setNewStrategy(StrategyLanguageSearchOrder strategy) {
-    verifyState();
-    this.strategy = strategy;
-  }
+  @Deprecated(
+      'setNewStrategy is no longer used and will be removed on future releases')
+  void setNewStrategy(StrategyLanguageSearchOrder strategy) {}
+
+  /// this count about a accidental recursive calling
+  @override
+  @Deprecated(
+      'reloadDictionarySync is no longer used and will be removed in future releases.')
+  void reloadDictionarySync() async {}
+
+  @override
+  @protected
+  @Deprecated(
+      'initDictionary is no longer used and will be removed in future releases.')
+  void initDictionary(dynamic words) {}
 }

--- a/lib/src/spell_checker_interface/abtract_checker.dart
+++ b/lib/src/spell_checker_interface/abtract_checker.dart
@@ -1,19 +1,9 @@
-// ignore_for_file: unused_field
-
 import 'dart:async';
-
-import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 import 'package:simple_spell_checker/src/spell_checker_interface/mixin/disposable.dart';
-import '../common/cache_object.dart';
 import '../common/language_identifier.dart';
 import '../common/strategy_language_search_order.dart';
-import '../utils.dart';
 import 'mixin/check_ops.dart';
-
-/// add a cache var let us add any custom language
-CacheObject<Set<String>> _languagesRegistry = CacheObject(
-  object: {...defaultLanguages},
-);
 
 abstract class Checker<T extends Object, R, OP extends Object>
     with CheckOperations<OP, R>, Disposable, DisposableStreams {
@@ -25,10 +15,14 @@ abstract class Checker<T extends Object, R, OP extends Object>
 
   /// If the current language is not founded on [customLanguages] or default ones,
   /// then select one of the existent to avoid conflicts
+  @Deprecated(
+      '_safeDictionaryLoad is no longer used and will be removed in future releases.')
   late bool _safeDictionaryLoad;
 
   /// If it is true then the spell checker
   /// ignores if the dictionary or language is not founded
+  @Deprecated(
+      '_worksWithoutDictionary is no longer used and will be removed in future releases')
   late bool _worksWithoutDictionary;
 
   final bool caseSensitive;
@@ -36,6 +30,8 @@ abstract class Checker<T extends Object, R, OP extends Object>
   /// the state of SimpleSpellChecker and to store to a existent language with its dictionary
   /// If _safeDictionaryLoad is true, this will be used as the default language to update
   final String safeLanguageName;
+  @Deprecated(
+      'strategy is no longer used and will be removed in future releases.')
   StrategyLanguageSearchOrder strategy;
 
   /// decide if the checker is disposed
@@ -44,45 +40,56 @@ abstract class Checker<T extends Object, R, OP extends Object>
   /// this just can be called on closeControllers
   bool _disposedControllers = false;
 
+  @Deprecated(
+      '_simpleSpellCheckerWidgetsState is no longer used and will be removed in future releases.')
   final StreamController<Object?> _simpleSpellCheckerWidgetsState =
       StreamController.broadcast();
   final StreamController<T?> _languageState = StreamController.broadcast();
   Checker({
     required T language,
-    bool safeDictionaryLoad = false,
-    bool worksWithoutDictionary = false,
     List<String> whiteList = const [],
     this.caseSensitive = true,
     this.safeLanguageName = 'en',
+    @Deprecated(
+        'safeDictionaryLoad is no longer used and will be removed in future releases.')
+    bool safeDictionaryLoad = false,
+    @Deprecated(
+        'worksWithoutDictionary is no longer used and will be removed in future releases')
+    bool worksWithoutDictionary = false,
+    @Deprecated(
+        'strategy is no longer used and will be removed in future releases.')
     this.strategy = StrategyLanguageSearchOrder.byPackage,
   }) {
     initializeChecker(
       language: language,
       whiteList: whiteList,
-      safeDictionaryLoad: safeDictionaryLoad,
-      worksWithoutDictionary: worksWithoutDictionary,
       safeLanguageName: safeLanguageName,
       caseSensitive: caseSensitive,
-      strategy: strategy,
     );
   }
 
   @protected
+  @Deprecated(
+      'safeDictionaryLoad is no longer used and will be removed in future releases.')
   bool get safeDictionaryLoad => _safeDictionaryLoad;
 
   @protected
+  @Deprecated(
+      'turnOffChecking is no longer used and will be removed in future releases.'
+      'Use isActiveChecking instead')
   bool get turnOffChecking => _turnOffChecking;
 
   @protected
-  void setRegistryToDefault() {
-    _languagesRegistry.set = {...defaultLanguages};
-  }
+  bool get isActiveChecking => !_turnOffChecking;
 
   @protected
-  List<String> get languagesRegistry =>
-      List.unmodifiable(_languagesRegistry.get);
+  @Deprecated(
+      'setRegistryToDefault is no longer used and will be removed in future releases.')
+  void setRegistryToDefault() {}
 
   @protected
+  @Deprecated(
+      'worksWithoutDictionary is no longer used and will be removed in future releases')
   bool get worksWithoutDictionary => _worksWithoutDictionary;
 
   List<String> get whiteList => [..._whiteList];
@@ -113,6 +120,8 @@ abstract class Checker<T extends Object, R, OP extends Object>
   /// You can use [defaultLanguagesDictionarie] that correspond with the current
   /// languages implemented into the package
   @protected
+  @Deprecated(
+      'initDictionary is no longer used and will be removed in future releases.')
   void initDictionary(String words);
 
   Stream get languageStream {
@@ -120,11 +129,15 @@ abstract class Checker<T extends Object, R, OP extends Object>
     return _languageState.stream;
   }
 
+  @Deprecated(
+      'stream method is not stable at the moment and will removed in future releases')
   Stream get stream {
     verifyState();
     return _simpleSpellCheckerWidgetsState.stream;
   }
 
+  @Deprecated(
+      'addCustomLanguage is no longer used and will be removed in future releases.')
   void addCustomLanguage(LanguageIdentifier language);
 
   @protected
@@ -137,6 +150,8 @@ abstract class Checker<T extends Object, R, OP extends Object>
 
   @protected
   @mustCallSuper
+  @Deprecated(
+      'addNewEventToWidgetsState is no longer used and will be removed in future releases')
   void addNewEventToWidgetsState(Object? object) {
     if (!_simpleSpellCheckerWidgetsState.isClosed || !_disposedControllers) {
       _simpleSpellCheckerWidgetsState.add(object);
@@ -147,6 +162,8 @@ abstract class Checker<T extends Object, R, OP extends Object>
   @override
   @mustCallSuper
   void dispose() {
+    // by now we will not removed this line since we need close the [StreamController]
+    // ignore: deprecated_member_use_from_same_package
     if (!_simpleSpellCheckerWidgetsState.isClosed)
       _simpleSpellCheckerWidgetsState.close();
     if (!_languageState.isClosed) _languageState.close();
@@ -158,6 +175,8 @@ abstract class Checker<T extends Object, R, OP extends Object>
   @override
   @mustCallSuper
   void disposeControllers() {
+    // by now we will not removed this line since we need close the [StreamController]
+    // ignore: deprecated_member_use_from_same_package
     if (!_simpleSpellCheckerWidgetsState.isClosed)
       _simpleSpellCheckerWidgetsState.close();
     if (!_languageState.isClosed) _languageState.close();
@@ -176,24 +195,28 @@ abstract class Checker<T extends Object, R, OP extends Object>
   void initializeChecker({
     required T language,
     List<String> whiteList = const [],
-    bool safeDictionaryLoad = false,
-    bool worksWithoutDictionary = false,
-    String safeLanguageName = 'en',
     bool caseSensitive = true,
+    @Deprecated(
+        'safeLanguageName is no longer used and will be removed in future releases.')
+    String safeLanguageName = 'en',
+    @Deprecated(
+        'safeDictionaryLoad is no longer used and will be removed in future releases.')
+    bool safeDictionaryLoad = false,
+    @Deprecated(
+        'worksWithoutDictionary is no longer used and will be removed in future releases.')
+    bool worksWithoutDictionary = false,
+    @Deprecated(
+        'strategy is no longer used and will be removed in future releases.')
     StrategyLanguageSearchOrder strategy =
         StrategyLanguageSearchOrder.byPackage,
   }) {
-    _languagesRegistry.set = {...defaultLanguages};
     _whiteList.addAll(List.from(whiteList));
-    addNewEventToWidgetsState(null);
     _language = language;
     addNewEventToLanguageState(_language);
-    _safeDictionaryLoad = safeDictionaryLoad;
-    _worksWithoutDictionary = worksWithoutDictionary;
-    this.strategy = strategy;
-    reloadDictionarySync();
   }
 
+  @Deprecated(
+      'isCheckerActive is no longer used and will be removed in future releases. Use isActiveChecking instead')
   bool isCheckerActive() {
     return !_turnOffChecking;
   }
@@ -202,22 +225,17 @@ abstract class Checker<T extends Object, R, OP extends Object>
   /// by the package to let you use customLanguages properly since
   /// we always check if the current language is already registered
   /// on [_languagesRegistry]
-  void registerLanguage(String language) {
-    verifyState();
-    if (!_languagesRegistry.get.contains(language)) {
-      _languagesRegistry.set = {..._languagesRegistry.get, language};
-    }
-  }
+  @Deprecated(
+      'registerLanguage is no longer used and will be removed in future releases. Use setLanguage instead')
+  void registerLanguage(String language) {}
 
   @override
-  Future<void> reloadDictionary() async {
-    verifyState();
-    reloadDictionarySync();
-  }
+  @Deprecated(
+      'registerLanguage is no longer used and will be removed in future releases.')
+  Future<void> reloadDictionary() async {}
 
   void reloadStreamStates() {
     verifyState();
-    _simpleSpellCheckerWidgetsState.add(null);
     _languageState.add(null);
   }
 
@@ -227,6 +245,8 @@ abstract class Checker<T extends Object, R, OP extends Object>
     addNewEventToLanguageState(_language);
   }
 
+  @Deprecated(
+      'setNewStrategy is no longer used and will be removed in future releases.')
   void setNewStrategy(StrategyLanguageSearchOrder strategy) {
     verifyState();
     this.strategy = strategy;
@@ -243,12 +263,11 @@ abstract class Checker<T extends Object, R, OP extends Object>
   /// Verify if [Checker] is not disposed yet
   @mustCallSuper
   @protected
+  @experimental
   void verifyState() {
     if (!_disposedControllers) {
       assert(
-        !_disposed &&
-            !_simpleSpellCheckerWidgetsState.isClosed &&
-            !_languageState.isClosed,
+        !_disposed && !_languageState.isClosed,
         'You cannot reuse this SimpleSpellchecker since you dispose it before',
       );
       return;

--- a/lib/src/spell_checker_interface/mixin/check_ops.dart
+++ b/lib/src/spell_checker_interface/mixin/check_ops.dart
@@ -3,8 +3,14 @@ import 'package:flutter/material.dart';
 
 mixin CheckOperations<T extends Object, R> {
   bool isWordValid(String word);
+  @Deprecated(
+      'reloadDictionary should not be used and will be removed on future releases.')
   Future<void> reloadDictionary();
+  @Deprecated(
+      'checkLanguageRegistry is no longer used and will be removed in future releases.')
   bool checkLanguageRegistry(R language);
+  @Deprecated(
+      'reloadDictionarySync is no longer used and will be removed in future releases.')
   void reloadDictionarySync();
   T? check(
     String text, {

--- a/lib/src/spell_checker_interface/mixin/stream_checks.dart
+++ b/lib/src/spell_checker_interface/mixin/stream_checks.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+@Deprecated(
+    'CheckOperationsStreams is no longer used and will be removed on future releases.')
 mixin CheckOperationsStreams<T extends Object> {
+  @Deprecated(
+      'checkStream should not be used and will be removed on future releases.')
   Stream<T?> checkStream(
     String text, {
     TextStyle? wrongStyle,
@@ -10,6 +14,8 @@ mixin CheckOperationsStreams<T extends Object> {
         customLongPressRecognizerOnWrongSpan,
   });
 
+  @Deprecated(
+      'checkBuilderStream should not be used and will be removed on future releases.')
   Stream<List<O>> checkBuilderStream<O>(
     String text, {
     required O Function(String, bool) builder,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,21 +1,4 @@
-import 'package:simple_spell_checker/src/dictionaries/bg/join_bulgarian_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/da/join_danish_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/de/ch/join_deutsch_ch_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/de/join_deutsch_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/en/gb/join_en_british_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/en/join_english_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/es/join_es_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/et/join_estonian_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/fr/join_french_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/he/join_hebrew_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/it/join_italian_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/ko/join_korean_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/nl/join_dutch_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/no/join_norwegian_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/pt/join_portuguese_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/ru/join_russian_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/sk/join_slovak_words.dart';
-import 'package:simple_spell_checker/src/dictionaries/sv/join_swedish_words.dart';
+import 'package:meta/meta.dart';
 
 final List<String> defaultLanguages = List.unmodifiable(
   [
@@ -42,27 +25,15 @@ final List<String> defaultLanguages = List.unmodifiable(
   ],
 );
 
-final Map<String, String> defaultLanguagesDictionaries = Map.unmodifiable({
-  'en': joinEnglishWords,
-  'en-gb': joinBritishWords,
-  'de': joinDeutschWords,
-  'de-ch': joinDeutschSwitzerlandWords,
-  'es': joinSpanishWords,
-  'it': joinItalianWords,
-  'fr': joinFrenchWords,
-  'no': joinNowergianWords,
-  'ko': joinKoreanWords,
-  'sv': joinSwedishWords,
-  'he': joinHebrewWords,
-  'et': joinEstonianWords,
-  'ca': joinDanishWords,
-  'sk': joinSlovakWords,
-  'nl': joinDutchWords,
-  'pt': joinPortugueseWords,
-  'bg': joinBulgarianWords,
-  'ru': joinRussianWords,
-});
+@Deprecated('defaultLanguagesDictionaries is no longer used and will be removed in future releases')
+final Map<String, String> defaultLanguagesDictionaries = Map.unmodifiable({});
 
+/// This variable is used by the checker to add using [setLanguage]
+/// where the key is the language code, and the value is the dictionary
+@experimental
+final Map<String, Map<String, int>> languagesToBeUsed = {};
+
+@experimental
 bool isWordHasNumber(String s) {
   return s.contains(RegExp(r'[0-9]'));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,10 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  collection: ^1.18.0
   flutter:
     sdk: flutter
+  meta: ^1.15.0
 
 dev_dependencies:
   flutter_test:

--- a/test/simple_spell_checker_test.dart
+++ b/test/simple_spell_checker_test.dart
@@ -7,7 +7,6 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final SimpleSpellChecker spellchecker = SimpleSpellChecker(
       language: 'en',
-      safeDictionaryLoad: false,
     );
     final content = spellchecker.checkBuilder<Map<String, bool>>(
         'this is a tśr (with) sme errors.', builder: (word, isValid) {
@@ -36,7 +35,6 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final SimpleSpellChecker spellchecker = SimpleSpellChecker(
       language: 'de',
-      safeDictionaryLoad: false,
     );
     //spellchecker.testingMode = false;
     final content = spellchecker.checkBuilder<Map<String, bool>>(
@@ -68,7 +66,6 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final SimpleSpellChecker spellchecker = SimpleSpellChecker(
       language: 'it',
-      safeDictionaryLoad: false,
     );
     //spellchecker.testingMode = false;
     final content = spellchecker.checkBuilder<Map<String, bool>>(
@@ -99,7 +96,6 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final SimpleSpellChecker spellchecker = SimpleSpellChecker(
       language: 'es',
-      safeDictionaryLoad: false,
     );
     //spellchecker.testingMode = false;
     final content = spellchecker.checkBuilder<Map<String, bool>>(
@@ -127,8 +123,6 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final SimpleSpellChecker spellchecker = SimpleSpellChecker(
       language: '',
-      safeDictionaryLoad: true,
-      worksWithoutDictionary: true,
     );
     final content = spellchecker.checkBuilder<Map<String, bool>>(
         'Questo è un test (con) aluni errori grammaticali',
@@ -163,7 +157,6 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     final SimpleSpellChecker spellchecker = SimpleSpellChecker(
       language: 'de',
-      safeDictionaryLoad: false,
     );
     spellchecker.dispose();
     // this should throws an error
@@ -174,70 +167,5 @@ void main() {
         return {word: isValid};
       });
     }, throwsA(isA<AssertionError>()));
-  });
-
-  // this process could be heavy since is loading different dictionaries
-  test('Should work with different languages at the same time', () {
-    TestWidgetsFlutterBinding.ensureInitialized();
-    final MultiSpellChecker spellchecker = MultiSpellChecker(
-      language: ['en', 'ru'],
-    );
-    final content = spellchecker.checkBuilder<Map<String, bool>>(
-        'Questo è un test (con) aluni errori grammaticali and правильно',
-        builder: (word, isValid) {
-      return {word: isValid};
-    });
-    expect(content, isNotNull);
-    expect(content, isNotEmpty);
-    expect(content, [
-      {'Questo': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'è': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'un': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'test ': true}, // is wrong
-      {'(': true}, // is not wrong
-      {'con': true}, // is wrong
-      {') ': true}, // is not wrong
-      {'aluni': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'errori': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'grammaticali': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'and ': true}, // is not wrong
-      {'правильно': true}, // is not wrong
-    ]);
-    spellchecker.registerLanguage('custom_it');
-    // automatically adds the new language to the current state
-    spellchecker.addCustomLanguage(const LanguageIdentifier(
-        language: 'custom_it', words: 'Questo\naluni'));
-    spellchecker.reloadDictionarySync();
-    final content2 = spellchecker.checkBuilder<Map<String, bool>>(
-        'Questo è un test (con) aluni errori grammaticali and правильно',
-        builder: (word, isValid) {
-      return {word: isValid};
-    });
-    expect(content2, isNotNull);
-    expect(content2, isNotEmpty);
-    expect(content2, [
-      {'Questo ': true}, // is wrong
-      {'è': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'un': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'test ': true}, // is wrong
-      {'(': true}, // is not wrong
-      {'con': true}, // is wrong
-      {') ': true}, // is not wrong
-      {'aluni ': true}, // is wrong
-      {'errori': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'grammaticali': false}, // is wrong
-      {' ': true}, // is not wrong
-      {'and ': true}, // is not wrong
-      {'правильно': true}, // is not wrong
-    ]);
   });
 }


### PR DESCRIPTION
## Description

Because `SimpleSpellChecker` is going to change, we decided to deprecate the vast majority of classes, variables and methods that will not be used now.

### Why are there so many methods deprecated?

This is because most of them were used to manage the cache, reload dictionaries that were in memory, or to add or update custom languages. These types of methods are no longer valid, since now the new way to be able to create new languages ​​and set your own dictionary is by using the static method setLanguage by yourself.

Also, these changes are necessary since we will separate the dictionaries by package in order to register them.

> [!IMPORTANT]
> `MultiSpellChecker` has been completely deprecated because the new implementation required is not compatible with what is done within this class. It is likely that it will be created again, but it would be much later and would be a completely new reimplementation.

## Relevant changes

- `LanguageIdentifier` has been deprecated since language handling has changed and will no longer be maintained.
- customLanguages ​​parameter from `SimpleSpellChecker` has been deprecated since we can now use `setLanguage` and deliver any new language with its own dictionaries
- The `checkStream` and `checkBuilderStream` functions have been deprecated since they will not be maintained and are not very requested as well as the `CheckOperationsStream` interface.
- Several constructor methods for either the Checker base class or `SimpleSpellChecker` have been deprecated: `safeLanguageName`,` safeDictionaryLoad`, `worksWithoutDictionary`, `strategy` and c`ustomLanguages` ​​since they are no longer used and will not be maintained
- static methods `setLanguage`, `unlearnWord` and `learnWord` have been added for direct handling of any language we have already registered.
- `isCheckerActive` has been deprecated and replaced by `isActiveChecking` to make it more meaningful when used.
- `defaultLanguagesDictionaries` has been deprecated and replaced by `languagesToBeUsed` (this name is subject to change)