### PR TITLE
Fix: remove public access to languages registration

### DIFF
--- a/lib/simple_spell_checker.dart
+++ b/lib/simple_spell_checker.dart
@@ -9,4 +9,4 @@ export 'src/common/extensions.dart';
 export 'src/common/tokenizer.dart';
 export 'src/simple_spell_checker.dart';
 export 'src/multi_spell_checker.dart';
-export 'src/utils.dart';
+export 'src/utils.dart' hide dictionaries, isWordHasNumber;

--- a/lib/src/simple_spell_checker.dart
+++ b/lib/src/simple_spell_checker.dart
@@ -242,8 +242,12 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
     dictionaries[language] = dictionary;
   }
 
-  static bool checkIfExistLanguage(String language){
+  static bool containsLanguage(String language){
     return dictionaries.containsKey(language);
+  }
+
+  static void removeLanguage(String language){
+    dictionaries.remove(language);
   }
 
   /// Check spelling in realtime

--- a/lib/src/simple_spell_checker.dart
+++ b/lib/src/simple_spell_checker.dart
@@ -76,7 +76,7 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
     }
     verifyState();
 
-    if (languagesToBeUsed[getCurrentLanguage()] == null) {
+    if (dictionaries[getCurrentLanguage()] == null) {
       return null;
     }
     if (!_wordTokenizer.canTokenizeText(text)) return null;
@@ -131,7 +131,7 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
       return null;
     }
     verifyState();
-    if (languagesToBeUsed[getCurrentLanguage()] == null) {
+    if (dictionaries[getCurrentLanguage()] == null) {
       throw UnsupportedError(
           'The ${getCurrentLanguage()} is not supported or registered. Please, first add your new language using [setLanguage] to avoid this message.');
     }
@@ -173,7 +173,7 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
     if (word.trim().isEmpty) return true;
     if (whiteList.contains(word)) return true;
     verifyState();
-    final wordsMap = languagesToBeUsed[getCurrentLanguage()] ?? {};
+    final wordsMap = dictionaries[getCurrentLanguage()] ?? {};
     final newWordWithCaseSensitive =
         caseSensitive ? word.toLowerCaseFirst() : word.trim().toLowerCase();
     final int? validWord = wordsMap[newWordWithCaseSensitive];
@@ -205,7 +205,7 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
   /// This will return all the words contained on the current state of the dictionary
   Map<String, int>? getDictionary() {
     verifyState();
-    return languagesToBeUsed[getCurrentLanguage()];
+    return dictionaries[getCurrentLanguage()];
   }
 
   @override
@@ -221,25 +221,29 @@ class SimpleSpellChecker extends Checker<String, String, List<TextSpan>> {
   static void setLanguage(String language, Map<String, int> words) {
     assert(language.trim().isNotEmpty,
         'language param cannot be empty or just contain whitespaces. Got [$language]');
-    languagesToBeUsed.addAll({language: words});
+    dictionaries.addAll({language: words});
   }
 
   static void unlearnWord(String language, String word) {
     assert(language.trim().isNotEmpty,
         'language param cannot be empty or just contain whitespaces. Got [$language]');
-    if (!languagesToBeUsed.containsKey(language)) return;
-    final dictionary = languagesToBeUsed[language] ?? {};
+    if (!dictionaries.containsKey(language)) return;
+    final dictionary = dictionaries[language] ?? {};
     dictionary.remove(word);
-    languagesToBeUsed[language] = dictionary;
+    dictionaries[language] = dictionary;
   }
 
   static void learnWord(String language, String word) {
     assert(language.trim().isNotEmpty,
         'language param cannot be empty or just contain whitespaces. Got [$language]');
-    if (!languagesToBeUsed.containsKey(language)) return;
-    final dictionary = languagesToBeUsed[language] ?? {};
+    if (!dictionaries.containsKey(language)) return;
+    final dictionary = dictionaries[language] ?? {};
     dictionary.addAll({word: 1});
-    languagesToBeUsed[language] = dictionary;
+    dictionaries[language] = dictionary;
+  }
+
+  static bool checkIfExistLanguage(String language){
+    return dictionaries.containsKey(language);
   }
 
   /// Check spelling in realtime

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -38,6 +38,7 @@ final Map<String, String> defaultLanguagesDictionaries = Map.unmodifiable({});
 final Map<String, Map<String, int>> dictionaries = {};
 
 @experimental
+@internal
 bool isWordHasNumber(String s) {
   return s.contains(RegExp(r'[0-9]'));
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -34,7 +34,8 @@ final Map<String, String> defaultLanguagesDictionaries = Map.unmodifiable({});
 /// This variable is used by the checker to add using [setLanguage]
 /// where the key is the language code, and the value is the dictionary
 @experimental
-final Map<String, Map<String, int>> languagesToBeUsed = {};
+@internal
+final Map<String, Map<String, int>> dictionaries = {};
 
 @experimental
 bool isWordHasNumber(String s) {

--- a/simple_spell_checker_ar_lan/lib/src/simple_spell_checker_ar.dart
+++ b/simple_spell_checker_ar_lan/lib/src/simple_spell_checker_ar.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_ar_lan/src/ar/join_arabic_words.dart';
 
 class SimpleSpellCheckerArRegister {
@@ -10,7 +10,7 @@ class SimpleSpellCheckerArRegister {
   /// `registerArabicLanguage` can be used to register manually the arabic
   /// language to be supported by the `SimpleSpellChecker`
   static void registerArabicLanguage() {
-    if (languagesToBeUsed.containsKey('ar')) return;
+    if (SimpleSpellChecker.containsLanguage('ar')) return;
     SimpleSpellChecker.setLanguage('ar', _createDictionary(joinArabicWords));
   }
 
@@ -29,6 +29,6 @@ class SimpleSpellCheckerArRegister {
   }
 
   static void unRegisterArabicLanguage() {
-    languagesToBeUsed.remove('ar');
+    SimpleSpellChecker.removeLanguage('ar');
   }
 }

--- a/simple_spell_checker_bg_lan/lib/src/simple_spell_checker_bg.dart
+++ b/simple_spell_checker_bg_lan/lib/src/simple_spell_checker_bg.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_bg_lan/src/bg/join_bulgarian_words.dart';
 
 class SimpleSpellCheckerBgRegister {
@@ -10,7 +10,7 @@ class SimpleSpellCheckerBgRegister {
   /// `registerBulgarianLanguage` can be used to register manually the bulgarian 
   /// language to be supported by the `SimpleSpellChecker`
   static void registerBulgarianLanguage() {
-    if (languagesToBeUsed.containsKey('bg')) return;
+    if (SimpleSpellChecker.containsLanguage('bg')) return;
     SimpleSpellChecker.setLanguage('bg', _createDictionary(joinBulgarianWords));
   }
 
@@ -29,6 +29,6 @@ class SimpleSpellCheckerBgRegister {
   }
 
   static void unRegisterBulgarianLanguage() {
-    languagesToBeUsed.remove('bg');
+    SimpleSpellChecker.removeLanguage('bg');
   }
 }

--- a/simple_spell_checker_ca_lan/lib/src/simple_spell_checker_ca.dart
+++ b/simple_spell_checker_ca_lan/lib/src/simple_spell_checker_ca.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_ca_lan/src/ca/join_catalan_words.dart';
 
 class SimpleSpellCheckerCaRegister {
@@ -10,7 +10,7 @@ class SimpleSpellCheckerCaRegister {
   /// `registerCatalanLanguage` can be used to register manually the catalan
   /// language to be supported by the `SimpleSpellChecker`
   static void registerCatalanLanguage() {
-    if (languagesToBeUsed.containsKey('ca')) return;
+    if (SimpleSpellChecker.containsLanguage('ca')) return;
     SimpleSpellChecker.setLanguage('ca', _createDictionary(joinCatalanWords));
   }
 
@@ -29,6 +29,6 @@ class SimpleSpellCheckerCaRegister {
   }
 
   static void unRegisterCatalanLanguage() {
-    languagesToBeUsed.remove('ca');
+    SimpleSpellChecker.removeLanguage('ca');
   }
 }

--- a/simple_spell_checker_da_lan/lib/src/simple_spell_checker_da.dart
+++ b/simple_spell_checker_da_lan/lib/src/simple_spell_checker_da.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_da_lan/src/da/join_danish_words.dart';
 
 class SimpleSpellCheckerDaRegister {
@@ -10,7 +10,7 @@ class SimpleSpellCheckerDaRegister {
   /// `registerDanishLanguage` can be used to register manually the danish 
   /// language to be supported by the `SimpleSpellChecker`
   static void registerDanishLanguage() {
-    if (languagesToBeUsed.containsKey('da')) return;
+    if (SimpleSpellChecker.containsLanguage('da')) return;
     SimpleSpellChecker.setLanguage('da', _createDictionary(joinDanishWords));
   }
 
@@ -29,6 +29,6 @@ class SimpleSpellCheckerDaRegister {
   }
 
   static void unRegisterDanishLanguage() {
-    languagesToBeUsed.remove('da');
+    SimpleSpellChecker.removeLanguage('da');
   }
 }

--- a/simple_spell_checker_de_lan/lib/src/simple_spell_checker_de.dart
+++ b/simple_spell_checker_de_lan/lib/src/simple_spell_checker_de.dart
@@ -13,7 +13,7 @@ class SimpleSpellCheckerDeRegister {
   static void registerDeutschLanguage({String preferDeutsch = 'de'}) {
     assert(preferDeutsch == 'de' || preferDeutsch == 'de-ch',
         'simple_spell_checker_de_lan only support "de" and "de-ch" languages by default. Got $preferDeutsch');
-    if (languagesToBeUsed.containsKey(preferDeutsch)) return;
+    if (SimpleSpellChecker.containsLanguage(preferDeutsch)) return;
     if (preferDeutsch == 'de') {
       SimpleSpellChecker.setLanguage('de', _createDictionary(joinDeutschWords));
     } else {
@@ -37,6 +37,7 @@ class SimpleSpellCheckerDeRegister {
   }
 
   static void unRegisterDeutschLanguage() {
-    languagesToBeUsed.remove('de');
+    SimpleSpellChecker.removeLanguage('de');
+    SimpleSpellChecker.removeLanguage('de-ch');
   }
 }

--- a/simple_spell_checker_en_lan/lib/src/simple_spell_checker_en.dart
+++ b/simple_spell_checker_en_lan/lib/src/simple_spell_checker_en.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_en_lan/src/en/gb/join_en_british_words.dart';
 import 'package:simple_spell_checker_en_lan/src/en/join_english_words.dart';
 
@@ -16,7 +16,7 @@ class SimpleSpellCheckerEnRegister {
   static void registerEnglishLanguage({String preferEnglish = 'en'}) {
     assert(preferEnglish == 'en' || preferEnglish == 'en-gb',
         'simple_spell_checker_en_lan only support "en" and "en-gb" languages by default. Got $preferEnglish');
-    if (languagesToBeUsed.containsKey(preferEnglish)) return;
+    if (SimpleSpellChecker.containsLanguage(preferEnglish)) return;
     if (preferEnglish == 'en') {
       SimpleSpellChecker.setLanguage('en', _createDictionary(joinEnglishWords));
     } else {
@@ -40,7 +40,7 @@ class SimpleSpellCheckerEnRegister {
   }
 
   static void unRegisterEnglishLanguage() {
-    languagesToBeUsed.remove('en');
-    languagesToBeUsed.remove('en-gb');
+    SimpleSpellChecker.removeLanguage('en');
+    SimpleSpellChecker.removeLanguage('en-gb');
   }
 }

--- a/simple_spell_checker_es_lan/lib/src/simple_spell_checker_es.dart
+++ b/simple_spell_checker_es_lan/lib/src/simple_spell_checker_es.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_es_lan/src/es/join_es_words.dart';
 
 class SimpleSpellCheckerEsRegister {
@@ -10,7 +10,7 @@ class SimpleSpellCheckerEsRegister {
   /// `registerSpanishLanguage` can be used to register manually the spanish 
   /// language to be supported by the `SimpleSpellChecker`
   static void registerSpanishLanguage() {
-    if (languagesToBeUsed.containsKey('es')) return;
+    if (SimpleSpellChecker.containsLanguage('es')) return;
     SimpleSpellChecker.setLanguage('es', _createDictionary(joinSpanishWords));
   }
 
@@ -29,6 +29,6 @@ class SimpleSpellCheckerEsRegister {
   }
 
   static void unRegisterSpanishLanguage() {
-    languagesToBeUsed.remove('es');
+    SimpleSpellChecker.removeLanguage('es');
   }
 }

--- a/simple_spell_checker_et_lan/lib/src/simple_spell_checker_et.dart
+++ b/simple_spell_checker_et_lan/lib/src/simple_spell_checker_et.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_et_lan/src/et/join_estonian_words.dart';
 
 class SimpleSpellCheckerEtRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerEtRegister {
   /// `registerEstonianLanguage` can be used to register manually the estonian
   /// language to be supported by the `SimpleSpellChecker`
   static void registerEstonianLanguage() {
-    if (languagesToBeUsed.containsKey('et')) return;
+    if (SimpleSpellChecker.containsLanguage('et')) return;
     SimpleSpellChecker.setLanguage('et', _createDictionary(joinEstonianWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerEtRegister {
   }
 
   static void unRegisterEstonianLanguage() {
-    languagesToBeUsed.remove('et');
+    SimpleSpellChecker.removeLanguage('et');
   }
 }

--- a/simple_spell_checker_fr_lan/lib/src/simple_spell_checker_fr.dart
+++ b/simple_spell_checker_fr_lan/lib/src/simple_spell_checker_fr.dart
@@ -1,7 +1,7 @@
 // ignore: depend_on_referenced_packages
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_fr_lan/src/fr/join_french_words.dart';
 
 class SimpleSpellCheckerFrRegister {
@@ -10,7 +10,7 @@ class SimpleSpellCheckerFrRegister {
   /// `registerFrenchLanguage` can be used to register manually the french
   /// language to be supported by the `SimpleSpellChecker`
   static void registerFrenchLanguage() {
-    if (languagesToBeUsed.containsKey('fr')) return;
+    if (SimpleSpellChecker.containsLanguage('fr')) return;
     SimpleSpellChecker.setLanguage('fr', _createDictionary(joinFrenchWords));
   }
 
@@ -29,6 +29,6 @@ class SimpleSpellCheckerFrRegister {
   }
 
   static void unRegisterFrenchLanguage() {
-    languagesToBeUsed.remove('fr');
+    SimpleSpellChecker.removeLanguage('fr');
   }
 }

--- a/simple_spell_checker_he_lan/lib/src/simple_spell_checker_he.dart
+++ b/simple_spell_checker_he_lan/lib/src/simple_spell_checker_he.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_he_lan/src/he/join_hebrew_words.dart';
 
 class SimpleSpellCheckerHeRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerHeRegister {
   /// `registerHebrewLanguage` can be used to register manually the hebrew
   /// language to be supported by the `SimpleSpellChecker`
   static void registerHebrewLanguage() {
-    if (languagesToBeUsed.containsKey('he')) return;
+    if (SimpleSpellChecker.containsLanguage('he')) return;
     SimpleSpellChecker.setLanguage('he', _createDictionary(joinHebrewWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerHeRegister {
   }
 
   static void unRegisterHebrewLanguage() {
-    languagesToBeUsed.remove('he');
+    SimpleSpellChecker.removeLanguage('he');
   }
 }

--- a/simple_spell_checker_it_lan/lib/src/simple_spell_checker_it.dart
+++ b/simple_spell_checker_it_lan/lib/src/simple_spell_checker_it.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_it_lan/src/it/join_italian_words.dart';
 
 class SimpleSpellCheckerItRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerItRegister {
   /// `registerItalianLanguage` can be used to register manually the italian
   /// language to be supported by the `SimpleSpellChecker`
   static void registerItalianLanguage() {
-    if (languagesToBeUsed.containsKey('it')) return;
+    if (SimpleSpellChecker.containsLanguage('it')) return;
     SimpleSpellChecker.setLanguage('it', _createDictionary(joinItalianWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerItRegister {
   }
 
   static void unRegisterItalianLanguage() {
-    languagesToBeUsed.remove('it');
+    SimpleSpellChecker.removeLanguage('it');
   }
 }

--- a/simple_spell_checker_ko_lan/lib/src/simple_spell_checker_ko.dart
+++ b/simple_spell_checker_ko_lan/lib/src/simple_spell_checker_ko.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_ko_lan/src/ko/join_korean_words.dart';
 
 class SimpleSpellCheckerKoRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerKoRegister {
   /// `registerKoreanLanguage` can be used to register manually the korean
   /// language to be supported by the `SimpleSpellChecker`
   static void registerKoreanLanguage() {
-    if (languagesToBeUsed.containsKey('ko')) return;
+    if (SimpleSpellChecker.containsLanguage('ko')) return;
     SimpleSpellChecker.setLanguage('ko', _createDictionary(joinKoreanWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerKoRegister {
   }
 
   static void unRegisterKoreanLanguage() {
-    languagesToBeUsed.remove('ko');
+    SimpleSpellChecker.removeLanguage('ko');
   }
 }

--- a/simple_spell_checker_nl_lan/lib/src/simple_spell_checker_nl.dart
+++ b/simple_spell_checker_nl_lan/lib/src/simple_spell_checker_nl.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_nl_lan/src/nl/join_dutch_words.dart';
 
 class SimpleSpellCheckerNlRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerNlRegister {
   /// `registerDutchLanguage` can be used to register manually the dutch
   /// language to be supported by the `SimpleSpellChecker`
   static void registerDutchLanguage() {
-    if (languagesToBeUsed.containsKey('nl')) return;
+    if (SimpleSpellChecker.containsLanguage('nl')) return;
     SimpleSpellChecker.setLanguage('nl', _createDictionary(joinDutchWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerNlRegister {
   }
 
   static void unRegisterDutchanguage() {
-    languagesToBeUsed.remove('nl');
+    SimpleSpellChecker.removeLanguage('nl');
   }
 }

--- a/simple_spell_checker_no_lan/lib/src/simple_spell_checker_no.dart
+++ b/simple_spell_checker_no_lan/lib/src/simple_spell_checker_no.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_no_lan/src/no/join_norwegian_words.dart';
 
 class SimpleSpellCheckerNoRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerNoRegister {
   /// `registerNorwegianLanguage` can be used to register manually the norwegian
   /// language to be supported by the `SimpleSpellChecker`
   static void registerNorwegianLanguage() {
-    if (languagesToBeUsed.containsKey('no')) return;
+    if (SimpleSpellChecker.containsLanguage('no')) return;
     SimpleSpellChecker.setLanguage('no', _createDictionary(joinNowergianWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerNoRegister {
   }
 
   static void unRegisterNorwegianLanguage() {
-    languagesToBeUsed.remove('no');
+    SimpleSpellChecker.removeLanguage('no');
   }
 }

--- a/simple_spell_checker_pt_lan/lib/src/simple_spell_checker_pt.dart
+++ b/simple_spell_checker_pt_lan/lib/src/simple_spell_checker_pt.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_pt_lan/src/pt/join_portuguese_words.dart';
 
 class SimpleSpellCheckerPtRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerPtRegister {
   /// `registerPortugueseLanguage` can be used to register manually the portuguese
   /// language to be supported by the `SimpleSpellChecker`
   static void registerPortugueseLanguage() {
-    if (languagesToBeUsed.containsKey('pt')) return;
+    if (SimpleSpellChecker.containsLanguage('pt')) return;
     SimpleSpellChecker.setLanguage(
         'pt', _createDictionary(joinPortugueseWords));
   }
@@ -29,6 +29,6 @@ class SimpleSpellCheckerPtRegister {
   }
 
   static void unRegisterPortugueseLanguage() {
-    languagesToBeUsed.remove('pt');
+    SimpleSpellChecker.removeLanguage('pt');
   }
 }

--- a/simple_spell_checker_ru_lan/lib/src/simple_spell_checker_ru.dart
+++ b/simple_spell_checker_ru_lan/lib/src/simple_spell_checker_ru.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:simple_spell_checker/simple_spell_checker.dart'
-    show SimpleSpellChecker, languagesToBeUsed;
+    show SimpleSpellChecker;
 import 'package:simple_spell_checker_ru_lan/src/ru/join_russian_words.dart';
 
 class SimpleSpellCheckerRuRegister {
@@ -9,7 +9,7 @@ class SimpleSpellCheckerRuRegister {
   /// `registerRussianLanguage` can be used to register manually the russian 
   /// language to be supported by the `SimpleSpellChecker`
   static void registerRussianLanguage() {
-    if (languagesToBeUsed.containsKey('ru')) return;
+    if (SimpleSpellChecker.containsLanguage('ru')) return;
     SimpleSpellChecker.setLanguage('ru', _createDictionary(joinRussianWords));
   }
 
@@ -28,6 +28,6 @@ class SimpleSpellCheckerRuRegister {
   }
 
   static void unRegisterRussianLanguage() {
-    languagesToBeUsed.remove('ru');
+    SimpleSpellChecker.removeLanguage('ru');
   }
 }


### PR DESCRIPTION
## Description

Because we want to keep it as simple as possible, we made the decision that `languagesToBeUsed` would be renamed to `dictionaries` and that it would now only be accessible `internally`.

To solve the problems that this brings, two new static methods were added to `SimpleSpellChecker`, which would be:

- **containsLanguage(String):** which, as its name suggests, is responsible for checking if the language passed to it exists within the registered dictionaries
- **removeLanguage(String):** which is responsible for removing a language from the dictionary.

## Why was this decision made?

All this is because by leaving this variable in public access, mutating it in an unexpected way outside the package could cause unexpected errors.