### PR TITLE
Fix(changelog): typo where there is a title instead the version where the change was maded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## What's Changed
+## 1.3.0
 
 * Chore!: first step to improve package by @CatHood0 in https://github.com/CatHood0/simple_spell_checker/pull/16
 


### PR DESCRIPTION
Due to a bug in the 1.3.0 update, a title was added referencing what had changed in this new version, instead of simply referencing which version this change was made in.