### PR TITLE
Chore!: renamed register functions from internal language packages

### DIFF
--- a/simple_spell_checker_ar_lan/lib/src/simple_spell_checker_ar.dart
+++ b/simple_spell_checker_ar_lan/lib/src/simple_spell_checker_ar.dart
@@ -7,9 +7,9 @@ import 'package:simple_spell_checker_ar_lan/src/ar/join_arabic_words.dart';
 class SimpleSpellCheckerArRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerArabicLanguage` can be used to register manually the arabic
+  /// this can be used to register manually the arabic
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerArabicLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('ar')) return;
     SimpleSpellChecker.setLanguage('ar', _createDictionary(joinArabicWords));
   }
@@ -28,7 +28,7 @@ class SimpleSpellCheckerArRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterArabicLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('ar');
   }
 }

--- a/simple_spell_checker_bg_lan/lib/src/simple_spell_checker_bg.dart
+++ b/simple_spell_checker_bg_lan/lib/src/simple_spell_checker_bg.dart
@@ -7,9 +7,9 @@ import 'package:simple_spell_checker_bg_lan/src/bg/join_bulgarian_words.dart';
 class SimpleSpellCheckerBgRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerBulgarianLanguage` can be used to register manually the bulgarian 
+  /// this can be used to register manually the bulgarian 
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerBulgarianLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('bg')) return;
     SimpleSpellChecker.setLanguage('bg', _createDictionary(joinBulgarianWords));
   }
@@ -28,7 +28,7 @@ class SimpleSpellCheckerBgRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterBulgarianLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('bg');
   }
 }

--- a/simple_spell_checker_ca_lan/lib/src/simple_spell_checker_ca.dart
+++ b/simple_spell_checker_ca_lan/lib/src/simple_spell_checker_ca.dart
@@ -7,9 +7,9 @@ import 'package:simple_spell_checker_ca_lan/src/ca/join_catalan_words.dart';
 class SimpleSpellCheckerCaRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerCatalanLanguage` can be used to register manually the catalan
+  /// this can be used to register manually the catalan
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerCatalanLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('ca')) return;
     SimpleSpellChecker.setLanguage('ca', _createDictionary(joinCatalanWords));
   }
@@ -28,7 +28,7 @@ class SimpleSpellCheckerCaRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterCatalanLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('ca');
   }
 }

--- a/simple_spell_checker_da_lan/lib/src/simple_spell_checker_da.dart
+++ b/simple_spell_checker_da_lan/lib/src/simple_spell_checker_da.dart
@@ -7,9 +7,9 @@ import 'package:simple_spell_checker_da_lan/src/da/join_danish_words.dart';
 class SimpleSpellCheckerDaRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerDanishLanguage` can be used to register manually the danish 
+  /// this can be used to register manually the danish 
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerDanishLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('da')) return;
     SimpleSpellChecker.setLanguage('da', _createDictionary(joinDanishWords));
   }
@@ -28,7 +28,7 @@ class SimpleSpellCheckerDaRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterDanishLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('da');
   }
 }

--- a/simple_spell_checker_de_lan/lib/src/simple_spell_checker_de.dart
+++ b/simple_spell_checker_de_lan/lib/src/simple_spell_checker_de.dart
@@ -10,6 +10,9 @@ class SimpleSpellCheckerDeRegister {
 
   /// this can be used to register manually the deutsch 
   /// language to be supported by the `SimpleSpellChecker`
+  ///
+  /// [`preferDeutsch`] can be only `de` or `de-ch` since just these options
+  /// are supported by the `simple_spell_checker_de_lan`
   static void registerLan({String preferDeutsch = 'de'}) {
     assert(preferDeutsch == 'de' || preferDeutsch == 'de-ch',
         'simple_spell_checker_de_lan only support "de" and "de-ch" languages by default. Got $preferDeutsch');

--- a/simple_spell_checker_de_lan/lib/src/simple_spell_checker_de.dart
+++ b/simple_spell_checker_de_lan/lib/src/simple_spell_checker_de.dart
@@ -8,9 +8,9 @@ import 'package:simple_spell_checker_de_lan/src/de/join_deutsch_words.dart';
 class SimpleSpellCheckerDeRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerDeutschLanguage` can be used to register manually the deutsch 
+  /// this can be used to register manually the deutsch 
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerDeutschLanguage({String preferDeutsch = 'de'}) {
+  static void registerLan({String preferDeutsch = 'de'}) {
     assert(preferDeutsch == 'de' || preferDeutsch == 'de-ch',
         'simple_spell_checker_de_lan only support "de" and "de-ch" languages by default. Got $preferDeutsch');
     if (SimpleSpellChecker.containsLanguage(preferDeutsch)) return;
@@ -36,7 +36,7 @@ class SimpleSpellCheckerDeRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterDeutschLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('de');
     SimpleSpellChecker.removeLanguage('de-ch');
   }

--- a/simple_spell_checker_en_lan/lib/src/simple_spell_checker_en.dart
+++ b/simple_spell_checker_en_lan/lib/src/simple_spell_checker_en.dart
@@ -8,12 +8,12 @@ import 'package:simple_spell_checker_en_lan/src/en/join_english_words.dart';
 class SimpleSpellCheckerEnRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerEnglishLanguage` can be used to register manually the english
+  /// this can be used to register manually the english
   /// language to be supported by the `SimpleSpellChecker`
   ///
   /// [`preferEnglish`] can be only `en` or `en-gb` since just these options
   /// are supported by the `simple_spell_checker_en_lan`
-  static void registerEnglishLanguage({String preferEnglish = 'en'}) {
+  static void registerLan({String preferEnglish = 'en'}) {
     assert(preferEnglish == 'en' || preferEnglish == 'en-gb',
         'simple_spell_checker_en_lan only support "en" and "en-gb" languages by default. Got $preferEnglish');
     if (SimpleSpellChecker.containsLanguage(preferEnglish)) return;
@@ -39,7 +39,7 @@ class SimpleSpellCheckerEnRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterEnglishLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('en');
     SimpleSpellChecker.removeLanguage('en-gb');
   }

--- a/simple_spell_checker_es_lan/lib/src/simple_spell_checker_es.dart
+++ b/simple_spell_checker_es_lan/lib/src/simple_spell_checker_es.dart
@@ -7,9 +7,9 @@ import 'package:simple_spell_checker_es_lan/src/es/join_es_words.dart';
 class SimpleSpellCheckerEsRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerSpanishLanguage` can be used to register manually the spanish 
+  /// this can be used to register manually the spanish 
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerSpanishLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('es')) return;
     SimpleSpellChecker.setLanguage('es', _createDictionary(joinSpanishWords));
   }
@@ -28,7 +28,7 @@ class SimpleSpellCheckerEsRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterSpanishLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('es');
   }
 }

--- a/simple_spell_checker_et_lan/lib/src/simple_spell_checker_et.dart
+++ b/simple_spell_checker_et_lan/lib/src/simple_spell_checker_et.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_et_lan/src/et/join_estonian_words.dart';
 class SimpleSpellCheckerEtRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerEstonianLanguage` can be used to register manually the estonian
+  /// this can be used to register manually the estonian
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerEstonianLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('et')) return;
     SimpleSpellChecker.setLanguage('et', _createDictionary(joinEstonianWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerEtRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterEstonianLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('et');
   }
 }

--- a/simple_spell_checker_fr_lan/lib/src/simple_spell_checker_fr.dart
+++ b/simple_spell_checker_fr_lan/lib/src/simple_spell_checker_fr.dart
@@ -7,9 +7,9 @@ import 'package:simple_spell_checker_fr_lan/src/fr/join_french_words.dart';
 class SimpleSpellCheckerFrRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerFrenchLanguage` can be used to register manually the french
+  /// this can be used to register manually the french
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerFrenchLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('fr')) return;
     SimpleSpellChecker.setLanguage('fr', _createDictionary(joinFrenchWords));
   }
@@ -28,7 +28,7 @@ class SimpleSpellCheckerFrRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterFrenchLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('fr');
   }
 }

--- a/simple_spell_checker_he_lan/lib/src/simple_spell_checker_he.dart
+++ b/simple_spell_checker_he_lan/lib/src/simple_spell_checker_he.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_he_lan/src/he/join_hebrew_words.dart';
 class SimpleSpellCheckerHeRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerHebrewLanguage` can be used to register manually the hebrew
+  /// this can be used to register manually the hebrew
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerHebrewLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('he')) return;
     SimpleSpellChecker.setLanguage('he', _createDictionary(joinHebrewWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerHeRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterHebrewLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('he');
   }
 }

--- a/simple_spell_checker_it_lan/lib/src/simple_spell_checker_it.dart
+++ b/simple_spell_checker_it_lan/lib/src/simple_spell_checker_it.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_it_lan/src/it/join_italian_words.dart';
 class SimpleSpellCheckerItRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerItalianLanguage` can be used to register manually the italian
+  /// this can be used to register manually the italian
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerItalianLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('it')) return;
     SimpleSpellChecker.setLanguage('it', _createDictionary(joinItalianWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerItRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterItalianLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('it');
   }
 }

--- a/simple_spell_checker_ko_lan/lib/src/simple_spell_checker_ko.dart
+++ b/simple_spell_checker_ko_lan/lib/src/simple_spell_checker_ko.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_ko_lan/src/ko/join_korean_words.dart';
 class SimpleSpellCheckerKoRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerKoreanLanguage` can be used to register manually the korean
+  /// this can be used to register manually the korean
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerKoreanLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('ko')) return;
     SimpleSpellChecker.setLanguage('ko', _createDictionary(joinKoreanWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerKoRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterKoreanLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('ko');
   }
 }

--- a/simple_spell_checker_nl_lan/lib/src/simple_spell_checker_nl.dart
+++ b/simple_spell_checker_nl_lan/lib/src/simple_spell_checker_nl.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_nl_lan/src/nl/join_dutch_words.dart';
 class SimpleSpellCheckerNlRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerDutchLanguage` can be used to register manually the dutch
+  /// this can be used to register manually the dutch
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerDutchLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('nl')) return;
     SimpleSpellChecker.setLanguage('nl', _createDictionary(joinDutchWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerNlRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterDutchanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('nl');
   }
 }

--- a/simple_spell_checker_no_lan/lib/src/simple_spell_checker_no.dart
+++ b/simple_spell_checker_no_lan/lib/src/simple_spell_checker_no.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_no_lan/src/no/join_norwegian_words.dart';
 class SimpleSpellCheckerNoRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerNorwegianLanguage` can be used to register manually the norwegian
+  /// this can be used to register manually the norwegian
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerNorwegianLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('no')) return;
     SimpleSpellChecker.setLanguage('no', _createDictionary(joinNowergianWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerNoRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterNorwegianLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('no');
   }
 }

--- a/simple_spell_checker_pt_lan/lib/src/simple_spell_checker_pt.dart
+++ b/simple_spell_checker_pt_lan/lib/src/simple_spell_checker_pt.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_pt_lan/src/pt/join_portuguese_words.dart';
 class SimpleSpellCheckerPtRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerPortugueseLanguage` can be used to register manually the portuguese
+  /// this can be used to register manually the portuguese
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerPortugueseLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('pt')) return;
     SimpleSpellChecker.setLanguage(
         'pt', _createDictionary(joinPortugueseWords));
@@ -28,7 +28,7 @@ class SimpleSpellCheckerPtRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterPortugueseLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('pt');
   }
 }

--- a/simple_spell_checker_ru_lan/lib/src/simple_spell_checker_ru.dart
+++ b/simple_spell_checker_ru_lan/lib/src/simple_spell_checker_ru.dart
@@ -6,9 +6,9 @@ import 'package:simple_spell_checker_ru_lan/src/ru/join_russian_words.dart';
 class SimpleSpellCheckerRuRegister {
   static const _splitter = LineSplitter();
 
-  /// `registerRussianLanguage` can be used to register manually the russian 
+  /// this can be used to register manually the russian 
   /// language to be supported by the `SimpleSpellChecker`
-  static void registerRussianLanguage() {
+  static void registerLan() {
     if (SimpleSpellChecker.containsLanguage('ru')) return;
     SimpleSpellChecker.setLanguage('ru', _createDictionary(joinRussianWords));
   }
@@ -27,7 +27,7 @@ class SimpleSpellCheckerRuRegister {
     return {}..addEntries(entries);
   }
 
-  static void unRegisterRussianLanguage() {
+  static void removeLan() {
     SimpleSpellChecker.removeLanguage('ru');
   }
 }


### PR DESCRIPTION
## Description

As stated in https://github.com/CatHood0/simple_spell_checker/pull/16#issuecomment-2380571423 it was taken into consideration that the functions used within the packages containing the dictionaries implemented by default had to be renamed.

This was a problem in itself because the registration functions were constantly being renamed according to the language used in the package, which makes the API itself inconsistent and if later on we plan to make classes like `SimpleSpellCheckerRuRegister` extend from some other interface to fulfill a contract, this would force us to reimplement (i.e. what is done here) all the methods again, which we do not want.

### An example of how this change improve the readability and the API between the internal packages

#### Before the change:
```dart
// for Russian
SimpleSpellCheckerRuRegister.registerRussianLanguage();
SimpleSpellCheckerRuRegister.unRegisterRussianLanguage();
// for Hebrew
SimpleSpellCheckerHeRegister.registerHebrewLanguage();
SimpleSpellCheckerHeRegister.unRegisterHebrewLanguage();
```
#### After the change
```dart
// for Russian
SimpleSpellCheckerRuRegister.registerLan();
SimpleSpellCheckerRuRegister.removeLan();
// for Hebrew
SimpleSpellCheckerHeRegister.registerLan();
SimpleSpellCheckerHeRegister.removeLan();
```
This way we now have a more unified API and it will prevent us from making breaking changes in the near future.